### PR TITLE
feat: add internal ID handling for item categories

### DIFF
--- a/AvatarExplorer.Core/Models/Items/ItemCategory.cs
+++ b/AvatarExplorer.Core/Models/Items/ItemCategory.cs
@@ -57,4 +57,30 @@ public class ItemCategory : ISelectableItem
     #endregion
 
     public override string ToString() => Type == ItemType.Custom ? CustomCategory : (Type.GetLocalizationKey() ?? Type.ToString());
+
+    private const string CustomCategoryPrefix = "<sys:customcategory>";
+    private const string ItemCategoryPrefix = "<sys:itemcategory>";
+    public string GetInternalId() => Type == ItemType.Custom ? CustomCategoryPrefix + CustomCategory : ItemCategoryPrefix + Type.ToString();
+
+    public static bool TryParse(string internalId, out ItemCategory? category)
+    {
+        category = default;
+
+        if (internalId.StartsWith(CustomCategoryPrefix))
+        {
+            category = new ItemCategory(internalId[CustomCategoryPrefix.Length..]);
+            return true;
+        }
+        else if (internalId.StartsWith(ItemCategoryPrefix))
+        {
+            string itemTypeString = internalId[ItemCategoryPrefix.Length..];
+            if (Enum.TryParse(itemTypeString, out ItemType itemType))
+            {
+                category = new ItemCategory(itemType);
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/AvatarExplorer.UI/Services/ViewControl/ContextMenuCreator.cs
+++ b/AvatarExplorer.UI/Services/ViewControl/ContextMenuCreator.cs
@@ -111,8 +111,7 @@ internal static class ContextMenuCreator
 
         if (itemCategory.Type != ItemType.All)
         {
-            string itemCategoryName = itemCategory.Type == ItemType.Custom ? "<sys:customcategory>" + itemCategory.CustomCategory : "<sys:itemcategory>" + itemCategory.Type;
-            contextMenuActions.Add(new ContextMenuAction(LocalizationKey.ContextMenu.ItemCategory.MergeWithOtherCategory, ActionKey.MergeWithOtherCategory, ContextMenuIconType.Merge, itemCategoryName));
+            contextMenuActions.Add(new ContextMenuAction(LocalizationKey.ContextMenu.ItemCategory.MergeWithOtherCategory, ActionKey.MergeWithOtherCategory, ContextMenuIconType.Merge, itemCategory.GetInternalId()));
         }
 
         if (itemCategory.Type == ItemType.Custom)

--- a/AvatarExplorer.UI/Views/MainWindow/MainWindow.ContextMenuEventHandlers.cs
+++ b/AvatarExplorer.UI/Views/MainWindow/MainWindow.ContextMenuEventHandlers.cs
@@ -338,25 +338,9 @@ public partial class MainWindow
 
     private async Task Main_ItemButton_ContextMenu_MergeWithOtherCategory(string categoryName)
     {
-        ItemCategory sourceCategory;
-        if (categoryName.StartsWith("<sys:customcategory>"))
+        if (!ItemCategory.TryParse(categoryName, out ItemCategory? sourceCategory) || sourceCategory == null)
         {
-            string customCategoryName = categoryName.Substring("<sys:customcategory>".Length);
-            sourceCategory = new ItemCategory(customCategoryName);
-        }
-        else if (categoryName.StartsWith("<sys:itemcategory>"))
-        {
-            string itemCategoryName = categoryName.Substring("<sys:itemcategory>".Length);
-            if (!Enum.TryParse(itemCategoryName, out ItemType itemType))
-            {
-                DialogOverlay_Show(Localizer.Instance[LocalizationKey.Error.Default], Localizer.Instance[LocalizationKey.Error.InvalidCategory]);
-                return;
-            }
-
-            sourceCategory = new ItemCategory(itemType);
-        }
-        else
-        {
+            DialogOverlay_Show(Localizer.Instance[LocalizationKey.Error.Default], Localizer.Instance[LocalizationKey.Error.InvalidCategory]);
             return;
         }
 


### PR DESCRIPTION
- Introduced `GetInternalId` method in `ItemCategory` to generate unique internal IDs for custom and predefined categories.
- Added `TryParse` method to parse internal IDs back into `ItemCategory` instances.
- Refactored context menu creation to use `GetInternalId` for category identification.
- Simplified `Main_ItemButton_ContextMenu_MergeWithOtherCategory` logic by replacing manual string parsing with `TryParse`.