### PR TITLE
feat: implement tab click initialization and toggle behavior for sidepanel tabs

### DIFF
--- a/AvatarExplorer.UI/Views/MainWindow.axaml
+++ b/AvatarExplorer.UI/Views/MainWindow.axaml
@@ -118,7 +118,7 @@
                             <Grid RowSpacing="10">
                                 <Grid Grid.Row="2" ColumnSpacing="10">
                                     <TabControl x:Name="SidePanel_TabControl" HorizontalAlignment="Stretch" SelectedIndex="0" FontSize="18" Margin="0,0,-10,0" TabStripPlacement="Right">
-                                        <TabItem ToolTip.Tip="{Binding [SidePanel.AdvancedSearch]}" DoubleTapped="SidePanel_TabItem_DoubleTapped">
+                                        <TabItem x:Name="SidePanel_AdvancedSearchTab" ToolTip.Tip="{Binding [SidePanel.AdvancedSearch]}">
                                             <TabItem.Header>
                                                 <materialIcons:MaterialIcon Kind="TextSearch" Width="16" Height="16"/>
                                             </TabItem.Header>
@@ -211,7 +211,7 @@
                                             </Grid>
                                         </TabItem>
 
-                                        <TabItem x:Name="SidePanel_BulkImportPanelTab" ToolTip.Tip="{Binding [SidePanel.BulkImport]}" DoubleTapped="SidePanel_TabItem_DoubleTapped">
+                                        <TabItem x:Name="SidePanel_BulkImportPanelTab" ToolTip.Tip="{Binding [SidePanel.BulkImport]}">
                                             <TabItem.Header>
                                                 <materialIcons:MaterialIcon Kind="DownloadMultiple" Width="16" Height="16"/>
                                             </TabItem.Header>
@@ -233,7 +233,7 @@
                                             </Grid>
                                         </TabItem>
 
-                                        <TabItem x:Name="SidePanel_BulkImportPresetPanelTab" ToolTip.Tip="{Binding [SidePanel.BulkImportPreset]}" DoubleTapped="SidePanel_TabItem_DoubleTapped">
+                                        <TabItem x:Name="SidePanel_BulkImportPresetPanelTab" ToolTip.Tip="{Binding [SidePanel.BulkImportPreset]}">
                                             <TabItem.Header>
                                                 <materialIcons:MaterialIcon Kind="FolderStarMultipleOutline" Width="16" Height="16"/>
                                             </TabItem.Header>

--- a/AvatarExplorer.UI/Views/MainWindow.axaml.cs
+++ b/AvatarExplorer.UI/Views/MainWindow.axaml.cs
@@ -70,6 +70,8 @@ public partial class MainWindow : Window
         Main_InitializeLanguageBox();
         Main_InitializeUserPreferences();
 
+        SidePanel_InitializeTabItemHandlers();
+
         Main_InitializePipeServer();
 
         // 設定画面の設定

--- a/AvatarExplorer.UI/Views/MainWindow/Overlays/MainWindow.SidePanelOverlay.cs
+++ b/AvatarExplorer.UI/Views/MainWindow/Overlays/MainWindow.SidePanelOverlay.cs
@@ -6,6 +6,12 @@ namespace AvatarExplorer.UI;
 
 public partial class MainWindow
 {
+    private void SidePanel_InitializeTabItemHandlers()
+    {
+        SidePanel_AdvancedSearchTab.AddHandler(PointerPressedEvent, SidePanel_Tab_Click, RoutingStrategies.Tunnel);
+        SidePanel_BulkImportPanelTab.AddHandler(PointerPressedEvent, SidePanel_Tab_Click, RoutingStrategies.Tunnel);
+        SidePanel_BulkImportPresetPanelTab.AddHandler(PointerPressedEvent, SidePanel_Tab_Click, RoutingStrategies.Tunnel);
+    }
     private void SidePanel_Show()
     {
         if (Main_SidePanelBorder.IsVisible) return;
@@ -33,6 +39,16 @@ public partial class MainWindow
         SidePanel_TabControl.SelectedIndex = itemIndex;
     }
 
-    private void SidePanel_TabItem_DoubleTapped(object? sender, RoutedEventArgs e) => SidePanel_Hide(); // ダブルタップでサイドパネルを閉じる
+    private void SidePanel_Tab_Click(object? sender, PointerPressedEventArgs e)
+    {
+        // TabItem
+        if (sender is not TabItem tab) return;
+
+        int currentSelectedIndex = SidePanel_TabControl.SelectedIndex;
+        int index = SidePanel_TabControl.Items.IndexOf(tab);
+
+        // 既に表示されていた場合は閉じる
+        if (currentSelectedIndex == index) SidePanel_Hide();
+    }
     #endregion
 }


### PR DESCRIPTION
V12で機能しなくなったTabItem.PointerPressedを無理やり復活させました。
AddHandlerでRoutingStrategies.Tunnelで登録することで実現しています。