### PR TITLE
fix: switch to IWritableArchive to ensure proper disposal

### DIFF
--- a/AvatarExplorer.Core/Services/IO/FileSystemService.cs
+++ b/AvatarExplorer.Core/Services/IO/FileSystemService.cs
@@ -260,7 +260,7 @@ public static class FileSystemService
 
             reportProgress?.Invoke((LocalizationKey.Processing.Unitypackage.Status.Creating, 90));
 
-            await CreateTarArchive(saveFolderPath, unitypackagePath);
+            CreateTarArchive(saveFolderPath, unitypackagePath);
 
             DeleteDirectory(saveFolderPath, true);
 
@@ -366,20 +366,20 @@ public static class FileSystemService
 
         return processedEntries;
     }
-    private static async Task CreateTarArchive(string sourceFolder, string outputTarFile)
+    private static void CreateTarArchive(string sourceFolder, string outputTarFile)
     {
         if (!Directory.Exists(sourceFolder)) throw new DirectoryNotFoundException(sourceFolder);
 
-        IWritableAsyncArchive<TarWriterOptions> archive = await TarArchive.CreateAsyncArchive();
+        using IWritableArchive<TarWriterOptions> archive = TarArchive.CreateArchive();
 
         foreach (string filePath in EnumerateFiles(sourceFolder))
         {
             string relativePath = Path.GetRelativePath(sourceFolder, filePath);
-            await archive.AddEntryAsync(relativePath, filePath);
+            archive.AddEntry(relativePath, filePath);
         }
 
         using FileStream fileStream = new(outputTarFile, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 1024 * 1024, FileOptions.SequentialScan);
-        await archive.SaveToAsync(fileStream, new TarWriterOptions(CompressionType.None));
+        archive.SaveTo(fileStream, new TarWriterOptions(CompressionType.None));
     }
     #endregion
 


### PR DESCRIPTION
fix: #337 

Async版が動かなかったのはシンプルな実装ミスだったっぽいです
https://github.com/adamhathcock/sharpcompress/pull/1310

普通にusing忘れてたから解放してなかったのもあるけど、それを書いたとて動いていなかったのは事実... （なんか治ったみたいで安心？SharpCompressのバージョンが上がったらAsyncに戻します！）