### PR TITLE
fix(items): migrate item type values after enum reindex

### DIFF
--- a/AvatarExplorer.Core/Models/Items/ItemType.cs
+++ b/AvatarExplorer.Core/Models/Items/ItemType.cs
@@ -6,39 +6,39 @@ namespace AvatarExplorer.Core.Models.Items;
 public enum ItemType
 {
     [NonSelectable]
-    None = -1,
+    None,
 
     [LocalizationKey(LocalizationKey.ItemCategory.Avatar)]
-    Avatar = 0,
+    Avatar,
 
     [LocalizationKey(LocalizationKey.ItemCategory.Clothing)]
-    Clothing = 1,
+    Clothing,
 
     [LocalizationKey(LocalizationKey.ItemCategory.Texture)]
-    Texture = 2,
+    Texture,
 
     [LocalizationKey(LocalizationKey.ItemCategory.Gimmick)]
-    Gimmick = 3,
+    Gimmick,
 
     [LocalizationKey(LocalizationKey.ItemCategory.Accessory)]
-    Accessory = 4,
+    Accessory,
 
     [LocalizationKey(LocalizationKey.ItemCategory.HairStyle)]
-    HairStyle = 5,
+    HairStyle,
 
     [LocalizationKey(LocalizationKey.ItemCategory.Animation)]
-    Animation = 6,
+    Animation,
 
     [LocalizationKey(LocalizationKey.ItemCategory.Tool)]
-    Tool = 7,
+    Tool,
 
     [LocalizationKey(LocalizationKey.ItemCategory.Shader)]
-    Shader = 8,
+    Shader,
 
     [NonSelectable]
-    Custom = 9,
+    Custom,
 
     [NonSelectable]
     [LocalizationKey(LocalizationKey.ItemCategory.All)]
-    All = 10,
+    All,
 }

--- a/AvatarExplorer.Core/Services/IO/ItemDatabaseMigrationService.cs
+++ b/AvatarExplorer.Core/Services/IO/ItemDatabaseMigrationService.cs
@@ -5,12 +5,14 @@ namespace AvatarExplorer.Core.Services.IO;
 
 internal static class ItemDatabaseMigrationService
 {
-    private const int CurrentMigrationVersion = 1;
+    private const int CurrentMigrationVersion = 2;
 
     private const string LegacyThumbnailKey = "ThumbnmailFileName";
     private const string ThumbnailKey = "ThumbnailFileName";
 
-    internal static void MigrateThumbnailKey(string filePath)
+    private const int ItemTypeOffset = 1; // ItemType enum values were shifted up by 1 in version 2
+
+    internal static void Migrate(string filePath)
     {
         try
         {
@@ -53,6 +55,7 @@ internal static class ItemDatabaseMigrationService
         return targetVersion switch
         {
             1 => MigrateV1RenameThumbnailKey(items),
+            2 => MigrateV2ItemTypeOffset(items),
             _ => false
         };
     }
@@ -76,6 +79,26 @@ internal static class ItemDatabaseMigrationService
             }
 
             itemObject.Remove(LegacyThumbnailKey);
+            changed = true;
+        }
+
+        return changed;
+    }
+
+    private static bool MigrateV2ItemTypeOffset(JsonArray items)
+    {
+        bool changed = false;
+
+        foreach (JsonNode? itemNode in items)
+        {
+            if (itemNode is not JsonObject itemObject) continue;
+            if (!itemObject.ContainsKey("Type")) continue;
+
+            JsonNode? typeNode = itemObject["Type"];
+            if (typeNode is not JsonValue typeValue || !typeValue.TryGetValue(out int typeInt)) continue;
+
+            int migratedTypeInt = typeInt + ItemTypeOffset;
+            itemObject["Type"] = migratedTypeInt;
             changed = true;
         }
 

--- a/AvatarExplorer.Core/Services/System/AvatarExplorerApp.Database.cs
+++ b/AvatarExplorer.Core/Services/System/AvatarExplorerApp.Database.cs
@@ -12,7 +12,7 @@ public partial class AvatarExplorerApp
     public void LoadItemDatabase(string? path = null)
     {
         string loadPath = path ?? SystemPath.ItemDatabasePath;
-        ItemDatabaseMigrationService.MigrateThumbnailKey(loadPath);
+        ItemDatabaseMigrationService.Migrate(loadPath);
         _itemDatabaseManager.Load(loadPath);
         UpdateSearchIndex();
     }


### PR DESCRIPTION
add migration v2 to offset persisted item type ids by +1 and run unified migration on database load