### PR TITLE
fix(items): repair broken item addition flow

### DIFF
--- a/AvatarExplorer.Core/Models/Items/ItemCreationContext.cs
+++ b/AvatarExplorer.Core/Models/Items/ItemCreationContext.cs
@@ -1,3 +1,5 @@
+using AvatarExplorer.Core.Services.Network;
+
 namespace AvatarExplorer.Core.Models.Items;
 
 public class ItemCreationContext
@@ -12,4 +14,10 @@ public class ItemCreationContext
     public IEnumerable<string> SupportedAvatars { get; set; } = [];
     public string ItemMemo { get; set; } = string.Empty;
     public IEnumerable<string> Tags { get; set; } = [];
+
+    public async Task<bool> FetchThumbnailAsync(string destPath, bool overwrite = false)
+    {
+        if (string.IsNullOrEmpty(ThumbnailUrl)) return false;
+        return await ImageDownloader.Fetch(ThumbnailUrl, destPath, overwrite);
+    }
 }

--- a/AvatarExplorer.Core/Services/IO/FileSystemService.cs
+++ b/AvatarExplorer.Core/Services/IO/FileSystemService.cs
@@ -435,14 +435,19 @@ public static class FileSystemService
                 {
                     var copiedFolderPath = GetUniquePath(parentFolderPath, Path.GetFileName(itemPath), true);
                     var copyResult = await CopyDirectoryAsync(itemPath, copiedFolderPath, maxDegreeOfParallelism);
-                    if (copyResult.IsError) return Error.Failure(description: "Failed to copy directory.");
-
-                    result.ItemParentFolder = parentFolderPath;
+                    if (copyResult.IsError)
+                    {
+                        ErrorManager.Instance.PostInternalError($"Failed to copy directory: {itemPath}");
+                        result.ProcessingFailedPaths.Add(itemPath);
+                        continue;
+                    }
 
                     if (copyResult.Value.Failures.Count > 0)
                     {
                         copyResult.Value.Failures.ForEach(i => ErrorManager.Instance.PostInternalError($"Failed to copy: {i.SourcePath}", tag: i.ErrorMessage));
                     }
+                    
+                    result.ItemParentFolder = copiedFolderPath;
                 }
             }
         }
@@ -637,6 +642,16 @@ public static class FileSystemService
         if (!Directory.Exists(sourceDirectory))
             return Error.NotFound("Directory.Copy", $"Source directory not found: {sourceDirectory}");
 
+        try
+        {
+            Directory.CreateDirectory(destinationDirectory);
+        }
+        catch (Exception ex)
+        {
+            ErrorManager.Instance.PostInternalError("Failed to create destination directory.", ex);
+            return Error.Failure("Directory.Create", "Failed to create destination directory.");
+        }
+
         IEnumerable<string> allFiles;
 
         try
@@ -653,16 +668,6 @@ public static class FileSystemService
         int totalFiles = fileList.Count;
 
         if (totalFiles == 0) return new CopyResult { SuccessCount = 0, TotalCount = 0 };
-        
-        try
-        {
-            Directory.CreateDirectory(destinationDirectory);
-        }
-        catch (Exception ex)
-        {
-            ErrorManager.Instance.PostInternalError("Failed to create destination directory.", ex);
-            return Error.Failure("Directory.Create", "Failed to create destination directory.");
-        }
 
         int copiedFiles = 0;
         int lastReportedPercent = -1;

--- a/AvatarExplorer.Core/Services/System/Repositories/ItemRepository.cs
+++ b/AvatarExplorer.Core/Services/System/Repositories/ItemRepository.cs
@@ -48,7 +48,7 @@ public class ItemRepository
         OnUpdated?.Invoke();
     }
 
-    public Item Create(ItemCreationContext context)
+    public async Task<Item> Create(ItemCreationContext context)
     {
         var item = new Item();
         item.UpdateMetadata(
@@ -65,6 +65,10 @@ public class ItemRepository
         item.UpdateTags(context.Tags);
 
         _db.Add(item);
+
+        var destPath = Path.Combine(SystemPath.ItemThumbnailsFolderPath, item.Id);
+        var downloaded = await context.FetchThumbnailAsync(destPath, overwrite: true);
+        if (downloaded) item.UpdateThumbnailFileName(item.Id);
 
         Save();
         OnUpdated?.Invoke();
@@ -170,9 +174,12 @@ public class ItemRepository
         foreach (var rootFile in FileSystemService.EnumerateFiles(root, isRecursive: false))
             files.Add(new(root, rootFile));
 
-        foreach (var rootFolder in Directory.GetDirectories(root))
-            foreach (var rootFolderFile in FileSystemService.EnumerateFiles(rootFolder, isRecursive: true))
-                files.Add(new(rootFolder, rootFolderFile));
+        if (Directory.Exists(root))
+        {
+            foreach (var rootFolder in Directory.GetDirectories(root))
+                foreach (var rootFolderFile in FileSystemService.EnumerateFiles(rootFolder, isRecursive: true))
+                    files.Add(new(rootFolder, rootFolderFile));
+        }
 
         // Other Folders
         foreach (var otherFolder in item.ItemPaths)

--- a/AvatarExplorer.UI/ViewModels/Overlays/ItemEditorViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/ItemEditorViewModel.cs
@@ -25,7 +25,7 @@ namespace AvatarExplorer.UI.ViewModels.Overlays;
 public class ItemEditorViewModel : ViewModelBase
 {
     [Reactive] public bool IsVisible { get; set; } = false;
-    public string? ItemId { get; set; } = null;
+    public string? Identifier { get; set; } = null;
     public ObservableCollection<ItemPathViewModel> ItemPaths { get; set; } = [];
     [Reactive] public bool ShouldLinkToOriginal { get; set; } = false;
 
@@ -76,7 +76,7 @@ public class ItemEditorViewModel : ViewModelBase
 
     public void Open(string? itemId = null)
     {
-        ItemId = itemId;
+        Identifier = itemId;
         ItemPaths.Clear();
 
         RefleshCategories();
@@ -119,7 +119,7 @@ public class ItemEditorViewModel : ViewModelBase
     }
     public async void Open(LaunchInfo launchInfo)
     {
-        ItemId = null;
+        Identifier = null;
         ItemPaths.Clear();
 
         RefleshCategories();
@@ -181,11 +181,11 @@ public class ItemEditorViewModel : ViewModelBase
 
     private async Task Confirm()
     {
-        var identifier = ItemId != null ? await ConfirmEdit() : await ConfirmCreate();
+        var identifier = Identifier != null ? await ConfirmEdit(Identifier) : await ConfirmCreate();
         await AddPathsAsync(identifier);
     }
 
-    private async Task<string> ConfirmEdit()
+    private async Task<string> ConfirmEdit(string identifier)
     {
         var editContext = new ItemEditContext
         {
@@ -200,7 +200,6 @@ public class ItemEditorViewModel : ViewModelBase
             Tags = Tags.ToList()
         };
 
-        var identifier = $"item:{ItemId}";
         bool updateResult = AvatarExplorerApp.Instance.Items.Update(identifier, editContext);
         MainWindowViewModel.Instance.ShowNotification(
             Localizer.Instance[updateResult ? Loc.Success.Default : Loc.Error.Default],
@@ -219,23 +218,24 @@ public class ItemEditorViewModel : ViewModelBase
             BoothId = int.TryParse(BoothId, out var boothId) ? boothId : -1,
             ItemType = SelectedCategory?.Category.Type ?? ItemType.Avatar,
             CustomCategory = SelectedCategory?.Category.Type == ItemType.Custom ? SelectedCategory.Category.CustomCategory ?? string.Empty : string.Empty,
+            ThumbnailUrl = ThumbnailUrl,
             SupportedAvatars = SupportedAvatars,
             ItemMemo = Memo,
             Tags = Tags
         };
 
         var existingSameBoothIdItem = AvatarExplorerApp.Instance.Items.GetAll().FirstOrDefault(i => i.BoothId == creationContext.BoothId);
-        var addToExistingItem = await MainWindowViewModel.Instance.ShowYesNoDialog(
-            Localizer.Instance[Loc.Dialog.Confirmation.Default],
-            Localizer.Instance[Loc.Dialog.Confirmation.AddToExistingItem]
-        );
 
-        if (existingSameBoothIdItem != null && addToExistingItem)
+        if (existingSameBoothIdItem != null)
         {
-            return existingSameBoothIdItem.Identifier;
+            var addToExistingItem = await MainWindowViewModel.Instance.ShowYesNoDialog(
+                Localizer.Instance[Loc.Dialog.Confirmation.Default],
+                Localizer.Instance[Loc.Dialog.Confirmation.AddToExistingItem]
+            );
+            if (addToExistingItem) return existingSameBoothIdItem.Identifier;
         }
 
-        var item = AvatarExplorerApp.Instance.Items.Create(creationContext);
+        var item = await AvatarExplorerApp.Instance.Items.Create(creationContext);
         MainWindowViewModel.Instance.ShowNotification(
             Localizer.Instance[Loc.Success.Default],
             Localizer.Instance[Loc.Success.ItemAdd],


### PR DESCRIPTION
- fetch thumbnail asynchronously during item creation and persist file name
- record per-path copy failures instead of aborting whole directory copy
- set ItemParentFolder to the actual copied folder path
- create destination directory before enumerating files in CopyDirectoryAsync
- only prompt 'add to existing item' when a matching Booth ID item exists
- await async Create in ItemEditorViewModel

Fixes #467 