### PR TITLE
docs(contributing): remove obsolete architecture note and temporary naming rules

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,21 +105,6 @@ GitHub Copilot などの AI ツールを使うことは問題ありませんが�
 - プロジェクトのコーディング規約に準拠しているか
 - パフォーマンス上の問題がないか
 
-### アーキテクチャメモ
-
-現在の UI レイヤーでは、オーバーレイ関連の処理が MainWindow クラスに集中しています。MVVM 移行は別ブランチで進める予定のため、現時点では既存の設計に合わせて実装してください。
-
-現在のUIはWinFormsに近い設計で、コードを追うのが難しい状態です。
-別アーキテクチャへ移行するまでの間は、貢献のハードルが高いかもしれません。気になる点はIssueで知らせていただければ、こちらで対応します。
-
-#### 命名規則（暫定）
-- オーバーレイ専用のメンバーは `<Overlay名>_<メンバー名>` の形式で命名する
-- private フィールドは `_` + camelCase を使用する
-
-例:
-- `_hogeOverlay_foo`
-- `HogeOverlay_DoSomething`
-
 ---
 
 ## English
@@ -206,18 +191,3 @@ Review points:
 - Are edge cases considered?
 - Does it follow the project's coding conventions?
 - Are there performance concerns?
-
-### Architecture note
-
-In the current UI layer, overlay-related processing is concentrated in the MainWindow class. MVVM migration will be handled in a separate branch, so implement changes in a way that follows the current design.
-
-The current UI design is close to WinForms and can be difficult to follow.
-Before we migrate to another architecture, contribution may be challenging, so please let us know via an issue and we will fix it on our side.
-
-#### Temporary naming rules
-- Members dedicated to an overlay should follow `<OverlayName>_<MemberName>`
-- Private fields should use `_` + camelCase
-
-Examples:
-- `_hogeOverlay_foo`
-- `HogeOverlay_DoSomething`


### PR DESCRIPTION
The project has migrated to MVVM, so the WinForms-era architecture note and the temporary <OverlayName>_<MemberName> naming conventions are no longer relevant. Removing them avoids confusing new contributors with outdated guidance.