### PR TITLE
feat(ui): add notification when no Unitypackage found in bulk import

### DIFF
--- a/AvatarExplorer.Core/Data/Localization/en-US.json
+++ b/AvatarExplorer.Core/Data/Localization/en-US.json
@@ -230,6 +230,7 @@
     "Error.InvalidCategory": "Invalid category",
     "Error.InitializationFailed": "Failed to initialize the software. Please check the error log.",
     "Error.FetchAllItemThumbnailsFailed": "Bulk thumbnail fetch completed. Success: {0} / Failed: {1} / Total: {2}\nCheck the error log for details.",
+    "Error.UnitypackageNotFound": "No Unitypackage found",
 
     "Settings.Basic": "Basic",
     "Settings.Language.Title": "Language",

--- a/AvatarExplorer.Core/Data/Localization/es-ES.json
+++ b/AvatarExplorer.Core/Data/Localization/es-ES.json
@@ -229,6 +229,7 @@
     "Error.InvalidCategory": "Categoría inválida",
     "Error.InitializationFailed": "No se pudo inicializar el software. Consulta el registro de errores.",
     "Error.FetchAllItemThumbnailsFailed": "La obtención masiva de miniaturas se completó. Correctos: {0} / Fallidos: {1} / Total: {2}\nConsulta el registro de errores para más detalles.",
+    "Error.UnitypackageNotFound": "No se encontró ningún Unitypackage",
 
     "Settings.Basic": "Básico",
     "Settings.Language.Title": "Idioma",

--- a/AvatarExplorer.Core/Data/Localization/fr-FR.json
+++ b/AvatarExplorer.Core/Data/Localization/fr-FR.json
@@ -229,6 +229,7 @@
     "Error.InvalidCategory": "Catégorie invalide",
     "Error.InitializationFailed": "Échec de l'initialisation du logiciel. Veuillez consulter le journal d'erreurs.",
     "Error.FetchAllItemThumbnailsFailed": "La récupération groupée des vignettes est terminée. Réussies : {0} / Échouées : {1} / Total : {2}\nConsultez le journal d'erreurs pour plus de détails.",
+    "Error.UnitypackageNotFound": "Aucun Unitypackage trouvé",
 
     "Settings.Basic": "Général",
     "Settings.Language.Title": "Langue",

--- a/AvatarExplorer.Core/Data/Localization/ja-JP.json
+++ b/AvatarExplorer.Core/Data/Localization/ja-JP.json
@@ -229,6 +229,7 @@
     "Error.InvalidCategory": "無効なカテゴリです",
     "Error.InitializationFailed": "ソフトウェアの初期化に失敗しました。エラーログを確認してください。",
     "Error.FetchAllItemThumbnailsFailed": "サムネイル一括取得が完了しました。成功: {0}件 / 失敗: {1}件 / 合計: {2}件\n詳細はエラーログを確認してください。",
+    "Error.UnitypackageNotFound": "Unitypackageが見つかりませんでした",
 
     "Settings.Basic": "基本",
     "Settings.Language.Title": "言語",

--- a/AvatarExplorer.Core/Data/Localization/ko-KR.json
+++ b/AvatarExplorer.Core/Data/Localization/ko-KR.json
@@ -229,6 +229,7 @@
     "Error.InvalidCategory": "유효하지 않은 카테고리입니다",
     "Error.InitializationFailed": "소프트웨어 초기화에 실패했습니다. 오류 로그를 확인해 주세요.",
     "Error.FetchAllItemThumbnailsFailed": "썸네일 일괄 가져오기가 완료되었습니다. 성공: {0}개 / 실패: {1}개 / 전체: {2}개\n자세한 내용은 오류 로그를 확인해 주세요.",
+    "Error.UnitypackageNotFound": "Unitypackage를 찾을 수 없습니다",
 
     "Settings.Basic": "기본",
     "Settings.Language.Title": "언어",

--- a/AvatarExplorer.Core/Data/Localization/zh-CN.json
+++ b/AvatarExplorer.Core/Data/Localization/zh-CN.json
@@ -229,6 +229,7 @@
     "Error.InvalidCategory": "无效类别",
     "Error.InitializationFailed": "软件初始化失败。请查看错误日志。",
     "Error.FetchAllItemThumbnailsFailed": "批量获取缩略图完成。成功: {0} 个 / 失败: {1} 个 / 总计: {2} 个\n请查看错误日志了解详情。",
+    "Error.UnitypackageNotFound": "未找到Unitypackage",
 
     "Settings.Basic": "基本",
     "Settings.Language.Title": "语言",

--- a/AvatarExplorer.Core/Data/Localization/zh-TW.json
+++ b/AvatarExplorer.Core/Data/Localization/zh-TW.json
@@ -229,6 +229,7 @@
     "Error.InvalidCategory": "無效的類別",
     "Error.InitializationFailed": "軟體初始化失敗。請檢查錯誤日誌。",
     "Error.FetchAllItemThumbnailsFailed": "批次取得縮圖完成。成功: {0} 個 / 失敗: {1} 個 / 總計: {2} 個\n請查看錯誤日誌以取得詳細資訊。",
+    "Error.UnitypackageNotFound": "未找到Unitypackage",
 
     "Settings.Basic": "基本",
     "Settings.Language.Title": "語言",

--- a/AvatarExplorer.Core/Localization/LocalizationKeys.g.cs
+++ b/AvatarExplorer.Core/Localization/LocalizationKeys.g.cs
@@ -369,6 +369,7 @@ public static class Loc
         public const string InvalidCategory = "Error.InvalidCategory";
         public const string InitializationFailed = "Error.InitializationFailed";
         public const string FetchAllItemThumbnailsFailed = "Error.FetchAllItemThumbnailsFailed";
+        public const string UnitypackageNotFound = "Error.UnitypackageNotFound";
     }
     public static class Settings
     {

--- a/AvatarExplorer.UI/ViewModels/Panels/BulkImportViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Panels/BulkImportViewModel.cs
@@ -134,25 +134,32 @@ public class BulkImportViewModel : ViewModelBase
 
         var unitypackagePaths = UnitypackageService.GetUnitypackagePaths(item.GetFolderPaths());
 
-        if (unitypackagePaths.Length > 0)
+        if (unitypackagePaths.Length == 0)
         {
-            var bulkVm = new BulkImportItemViewModel()
-            {
-                ImageFileName = item.ThumbnailFileName,
-                TitleRaw = item.Title,
-                DescriptionRaw = new(Loc.Button.Description.Item.Author, [item.Author]),
-                UnitypackageFullPaths = unitypackagePaths.ToArray(),
-                ItemId = itemid,
-                SelectedUnitypackage = 0
-            };
-
-            if (!string.IsNullOrEmpty(filePath))
-            {
-                var index = unitypackagePaths.IndexOf(filePath);
-                if (index != -1) bulkVm.SelectedUnitypackage = index;
-            }
-
-            Items.Add(bulkVm.Update());
+            MainWindowViewModel.Instance.ShowNotification(
+                Localizer.Instance[Loc.Error.Default],
+                Localizer.Instance[Loc.Error.UnitypackageNotFound],
+                Avalonia.Controls.Notifications.NotificationType.Warning
+            );
+            return;
         }
+
+        var bulkVm = new BulkImportItemViewModel()
+        {
+            ImageFileName = item.ThumbnailFileName,
+            TitleRaw = item.Title,
+            DescriptionRaw = new(Loc.Button.Description.Item.Author, [item.Author]),
+            UnitypackageFullPaths = unitypackagePaths.ToArray(),
+            ItemId = itemid,
+            SelectedUnitypackage = 0
+        };
+
+        if (!string.IsNullOrEmpty(filePath))
+        {
+            var index = unitypackagePaths.IndexOf(filePath);
+            if (index != -1) bulkVm.SelectedUnitypackage = index;
+        }
+
+        Items.Add(bulkVm.Update());
     }
 }


### PR DESCRIPTION
Added warning notification in BulkImportViewModel.AddItem when no UnityPackage files are found in the selected folder. Previously, the method silently returned without user feedback. Now displays a warning notification using Error.Default title and Error.UnitypackageNotFound message across all 7 supported languages.

Closes #471 