### PR TITLE
feat(items): fetch thumbnail when editing item

### DIFF
--- a/AvatarExplorer.Core/Models/Items/ItemEditContext.cs
+++ b/AvatarExplorer.Core/Models/Items/ItemEditContext.cs
@@ -1,3 +1,5 @@
+using AvatarExplorer.Core.Services.Network;
+
 namespace AvatarExplorer.Core.Models.Items;
 
 public class ItemEditContext
@@ -5,6 +7,7 @@ public class ItemEditContext
     public string? Title { get; set; }
     public string? Author { get; set; }
     public string? AuthorId { get; set; }
+    public string? ThumbnailUrl { get; set; }
     public int? BoothId { get; set; }
     public ItemType? ItemType { get; set; }
     public string? CustomCategory { get; set; }
@@ -13,4 +16,10 @@ public class ItemEditContext
     public string? ItemMemo { get; set; }
     public string? ItemPath { get; set; }
     public IEnumerable<string>? Tags { get; set; }
+
+    public async Task<bool> FetchThumbnailAsync(string destPath, bool overwrite = false)
+    {
+        if (string.IsNullOrEmpty(ThumbnailUrl)) return false;
+        return await ImageDownloader.Fetch(ThumbnailUrl, destPath, overwrite);
+    }
 }

--- a/AvatarExplorer.Core/Services/System/Repositories/ItemRepository.cs
+++ b/AvatarExplorer.Core/Services/System/Repositories/ItemRepository.cs
@@ -75,7 +75,7 @@ public class ItemRepository
 
         return item;
     }
-    public bool Update(string identifier, ItemEditContext context)
+    public async Task<bool> Update(string identifier, ItemEditContext context)
     {
         var item = Get(identifier);
         if (item == null) return false;
@@ -91,6 +91,13 @@ public class ItemRepository
         if (context.SupportedAvatars != null) item.UpdateSupportedAvatars(context.SupportedAvatars);
         if (context.ImplementedAvatars != null) item.UpdateImplementedAvatars(context.ImplementedAvatars);
         if (context.Tags != null) item.UpdateTags(context.Tags);
+
+        if (context.ThumbnailUrl != null)
+        {
+            var destPath = Path.Combine(SystemPath.ItemThumbnailsFolderPath, item.Id);
+            var downloaded = await context.FetchThumbnailAsync(destPath, overwrite: true);
+            if (downloaded) item.UpdateThumbnailFileName(item.Id);
+        }
 
         var now = DatetimeUtils.GetCurrentUnixTime();
         item.UpdateTimestamp(now);

--- a/AvatarExplorer.UI/Services/ContextMenu/ContextMenuHandlerService.cs
+++ b/AvatarExplorer.UI/Services/ContextMenu/ContextMenuHandlerService.cs
@@ -134,7 +134,7 @@ public static class ContextMenuHandlerService
         );
         if (newTitle == null) return;
 
-        Items.Update(identifier, new() { Title = newTitle });
+        await Items.Update(identifier, new() { Title = newTitle });
     }
     private static async void EditItemMemo(string identifier)
     {
@@ -144,7 +144,7 @@ public static class ContextMenuHandlerService
         var newMemo = await MainWindowViewModel.Instance.ShowEditMemoDialog(item.ItemMemo);
         if (newMemo == null) return;
 
-        Items.Update(identifier, new() { ItemMemo = newMemo });
+        await Items.Update(identifier, new() { ItemMemo = newMemo });
     }
     private static void AddToBulkImportList(string identifier)
     {
@@ -187,7 +187,7 @@ public static class ContextMenuHandlerService
         );
         if (newAvatars == null) return;
 
-        Items.Update(identifier, new() { ImplementedAvatars = newAvatars });
+        await Items.Update(identifier, new() { ImplementedAvatars = newAvatars });
     }
     private static async void EditItemDefaultPath(string identifier)
     {
@@ -201,7 +201,7 @@ public static class ContextMenuHandlerService
         );
         if (folders == null || folders.Length == 0) return;
 
-        Items.Update(item.Identifier, new() { ItemPath = folders[0] });
+        await Items.Update(item.Identifier, new() { ItemPath = folders[0] });
     }
     private static async void EditItemTag(string identifier)
     {
@@ -211,7 +211,7 @@ public static class ContextMenuHandlerService
         var newTags = await MainWindowViewModel.Instance.ShowEditTagsDialog(item.Tags.ToArray());
         if (newTags == null) return;
 
-        Items.Update(item.Identifier, new() { Tags = newTags });
+        await Items.Update(item.Identifier, new() { Tags = newTags });
     }
     private static async void RemoveItem(string identifier)
     {

--- a/AvatarExplorer.UI/ViewModels/Overlays/ItemEditorViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/ItemEditorViewModel.cs
@@ -195,12 +195,13 @@ public class ItemEditorViewModel : ViewModelBase
             BoothId = ValueParser.Int(BoothId, -1),
             ItemType = SelectedCategory?.Category.Type ?? ItemType.Avatar,
             CustomCategory = SelectedCategory?.Category.Type == ItemType.Custom ? SelectedCategory.Category.CustomCategory : string.Empty,
+            ThumbnailUrl = ThumbnailUrl,
             SupportedAvatars = SupportedAvatars.ToList(),
             ItemMemo = Memo,
             Tags = Tags.ToList()
         };
 
-        bool updateResult = AvatarExplorerApp.Instance.Items.Update(identifier, editContext);
+        bool updateResult = await AvatarExplorerApp.Instance.Items.Update(identifier, editContext);
         MainWindowViewModel.Instance.ShowNotification(
             Localizer.Instance[updateResult ? Loc.Success.Default : Loc.Error.Default],
             Localizer.Instance[updateResult ? Loc.Success.ItemEdit : Loc.Error.ItemEditFailed],


### PR DESCRIPTION
Add ThumbnailUrl support to ItemEditContext and download the thumbnail during item update, mirroring the existing behavior in ItemCreationContext.

- Add ThumbnailUrl property and FetchThumbnailAsync to ItemEditContext
- Make ItemRepository.Update async; fetch thumbnail and update thumbnail file name when ThumbnailUrl is provided
- Set ThumbnailUrl in ItemEditorViewModel.ConfirmEdit and await the async Update call
- Update ContextMenuHandlerService callers to await Update