### PR TITLE
refactor(ui): unify thumbnail image load/unload handlers

### DIFF
--- a/AvatarExplorer.UI/Views/MainView.axaml
+++ b/AvatarExplorer.UI/Views/MainView.axaml
@@ -141,7 +141,7 @@
                                                     <Button Classes="button" Classes.accentbutton="{Binding IsSelected}" ContextMenu="{Binding ContextMenu}" ToolTip.Tip="{Binding ToolTip}" HorizontalAlignment="Stretch" VerticalAlignment="Top" CornerRadius="8" Padding="7" Margin="0,0,0,5" Command="{Binding $parent[UserControl].DataContext.SelectLeftItemCommand}" CommandParameter="{Binding}">
                                                         <Grid ColumnDefinitions="Auto,*" ColumnSpacing="10">
                                                             <Border CornerRadius="8" ClipToBounds="true" HorizontalAlignment="Center" VerticalAlignment="Top">
-                                                                <Image Source="{Binding Thumbnail}" Width="{Binding Width}" Height="{Binding Height}" Stretch="Fill" VerticalAlignment="Top"/>
+                                                                <Image Source="{Binding Thumbnail}" Width="{Binding Width}" Height="{Binding Height}" Stretch="Fill" VerticalAlignment="Top" Loaded="OnItemImageLoaded" Unloaded="OnItemImageUnloaded"/>
                                                             </Border>
 
                                                             <Grid Grid.Column="1" RowDefinitions="Auto,Auto,5,*">
@@ -221,7 +221,7 @@
                                                     <Button Classes="button" ContextMenu="{Binding ContextMenu}" ToolTip.Tip="{Binding ToolTip}" HorizontalAlignment="Stretch" VerticalAlignment="Top" CornerRadius="8" Padding="7" Margin="0,0,0,5" Command="{Binding $parent[UserControl].DataContext.SelectRightItemCommand}" CommandParameter="{Binding}" Loaded="OnMainItemButtonLoaded" Unloaded="OnMainItemButtonUnloaded">
                                                         <Grid ColumnDefinitions="Auto,*" ColumnSpacing="10">
                                                             <Border CornerRadius="8" ClipToBounds="true" HorizontalAlignment="Center" VerticalAlignment="Top">
-                                                                <Image Source="{Binding Thumbnail}" Width="{Binding Width}" Height="{Binding Height}" Stretch="Fill" VerticalAlignment="Top" Loaded="OnMainItemImageLoaded" Unloaded="OnMainItemImageUnloaded"/>
+                                                                <Image Source="{Binding Thumbnail}" Width="{Binding Width}" Height="{Binding Height}" Stretch="Fill" VerticalAlignment="Top" Loaded="OnItemImageLoaded" Unloaded="OnItemImageUnloaded"/>
                                                             </Border>
 
                                                             <Grid Grid.Column="1" RowDefinitions="Auto,Auto,5,*">

--- a/AvatarExplorer.UI/Views/MainView.axaml.cs
+++ b/AvatarExplorer.UI/Views/MainView.axaml.cs
@@ -180,7 +180,7 @@ public partial class MainView : UserControl
 
     public void CloseHoverWindow() => _hoverWindow.Close();
 
-    private void OnMainItemImageLoaded(object? sender, RoutedEventArgs e)
+    private void OnItemImageLoaded(object? sender, RoutedEventArgs e)
     {
         if (sender is not Image image) return;
 
@@ -189,17 +189,17 @@ public partial class MainView : UserControl
         if (bitmapInterpolationMode != BitmapInterpolationMode.None && bitmapInterpolationMode != BitmapInterpolationMode.Unspecified)
             RenderOptions.SetBitmapInterpolationMode(image, bitmapInterpolationMode);
 
-        image.PointerEntered += OnMainItemImagePointerEntered;
-        image.PointerExited += OnMainItemImagePointerExited;
-        image.PointerMoved += OnMainItemImagePointerMoved;
+        image.PointerEntered += OnItemImagePointerEntered;
+        image.PointerExited += OnItemImagePointerExited;
+        image.PointerMoved += OnItemImagePointerMoved;
     }
 
-    private void OnMainItemImageUnloaded(object? sender, RoutedEventArgs e)
+    private void OnItemImageUnloaded(object? sender, RoutedEventArgs e)
     {
         if (sender is not Image image) return;
-        image.PointerEntered -= OnMainItemImagePointerEntered;
-        image.PointerExited -= OnMainItemImagePointerExited;
-        image.PointerMoved -= OnMainItemImagePointerMoved;
+        image.PointerEntered -= OnItemImagePointerEntered;
+        image.PointerExited -= OnItemImagePointerExited;
+        image.PointerMoved -= OnItemImagePointerMoved;
     }
 
     private void OnMainItemButtonLoaded(object? sender, RoutedEventArgs e)
@@ -213,7 +213,7 @@ public partial class MainView : UserControl
         button.RemoveHandler(PointerPressedEvent, OnMainItemButtonPointerPressed);
     }
 
-    private void OnMainItemImagePointerEntered(object? sender, PointerEventArgs e)
+    private void OnItemImagePointerEntered(object? sender, PointerEventArgs e)
     {
         if (sender is not Image image || DataContext is not MainViewModel vm) return;
         if (image.DataContext is not ItemViewModel item) return;
@@ -222,13 +222,13 @@ public partial class MainView : UserControl
         vm.ShowHoverThumbnail(item);
     }
 
-    private void OnMainItemImagePointerExited(object? sender, PointerEventArgs e)
+    private void OnItemImagePointerExited(object? sender, PointerEventArgs e)
     {
         if (DataContext is not MainViewModel vm) return;
         vm.HideHoverThumbnail();
     }
 
-    private void OnMainItemImagePointerMoved(object? sender, PointerEventArgs e)
+    private void OnItemImagePointerMoved(object? sender, PointerEventArgs e)
     {
         if (DataContext is not MainViewModel vm) return;
         vm.UpdateHoverThumbnailPosition(GetScreenPosition(e));


### PR DESCRIPTION
Left item list thumbnails and the main item thumbnail now share the same OnItemImage* Loaded/Unloaded/PointerEntered/PointerExited/PointerMoved handlers, applying the hover-thumbnail logic consistently to both. Renames OnMainItemImage* handlers to OnItemImage*.