### PR TITLE
fix(hover): suppress tooltip while hover thumbnail is shown

### DIFF
--- a/AvatarExplorer.UI/Views/MainView.axaml
+++ b/AvatarExplorer.UI/Views/MainView.axaml
@@ -138,7 +138,7 @@
                                             <ItemsControl.ItemTemplate>
                                                 <DataTemplate x:DataType="component:ItemViewModel">
                                                 <!-- TODO: Implemented用のクラスも作るべきかも -->
-                                                    <Button Classes="button" Classes.accentbutton="{Binding IsSelected}" ContextMenu="{Binding ContextMenu}" ToolTip.Tip="{Binding ToolTip}" HorizontalAlignment="Stretch" VerticalAlignment="Top" CornerRadius="8" Padding="7" Margin="0,0,0,5" Command="{Binding $parent[UserControl].DataContext.SelectLeftItemCommand}" CommandParameter="{Binding}">
+                                                    <Button Classes="button" Classes.accentbutton="{Binding IsSelected}" ContextMenu="{Binding ContextMenu}" ToolTip.Tip="{Binding ToolTip}" ToolTip.ToolTipOpening="OnToolTipOpening" HorizontalAlignment="Stretch" VerticalAlignment="Top" CornerRadius="8" Padding="7" Margin="0,0,0,5" Command="{Binding $parent[UserControl].DataContext.SelectLeftItemCommand}" CommandParameter="{Binding}">
                                                         <Grid ColumnDefinitions="Auto,*" ColumnSpacing="10">
                                                             <Border CornerRadius="8" ClipToBounds="true" HorizontalAlignment="Center" VerticalAlignment="Top">
                                                                 <Image Source="{Binding Thumbnail}" Width="{Binding Width}" Height="{Binding Height}" Stretch="Fill" VerticalAlignment="Top" Loaded="OnItemImageLoaded" Unloaded="OnItemImageUnloaded"/>
@@ -218,7 +218,7 @@
 
                                             <ItemsControl.ItemTemplate>
                                                 <DataTemplate x:DataType="component:ItemViewModel">
-                                                    <Button Classes="button" ContextMenu="{Binding ContextMenu}" ToolTip.Tip="{Binding ToolTip}" HorizontalAlignment="Stretch" VerticalAlignment="Top" CornerRadius="8" Padding="7" Margin="0,0,0,5" Command="{Binding $parent[UserControl].DataContext.SelectRightItemCommand}" CommandParameter="{Binding}" Loaded="OnMainItemButtonLoaded" Unloaded="OnMainItemButtonUnloaded">
+                                                    <Button Classes="button" ContextMenu="{Binding ContextMenu}" ToolTip.Tip="{Binding ToolTip}" ToolTip.ToolTipOpening="OnToolTipOpening" HorizontalAlignment="Stretch" VerticalAlignment="Top" CornerRadius="8" Padding="7" Margin="0,0,0,5" Command="{Binding $parent[UserControl].DataContext.SelectRightItemCommand}" CommandParameter="{Binding}" Loaded="OnMainItemButtonLoaded" Unloaded="OnMainItemButtonUnloaded">
                                                         <Grid ColumnDefinitions="Auto,*" ColumnSpacing="10">
                                                             <Border CornerRadius="8" ClipToBounds="true" HorizontalAlignment="Center" VerticalAlignment="Top">
                                                                 <Image Source="{Binding Thumbnail}" Width="{Binding Width}" Height="{Binding Height}" Stretch="Fill" VerticalAlignment="Top" Loaded="OnItemImageLoaded" Unloaded="OnItemImageUnloaded"/>

--- a/AvatarExplorer.UI/Views/MainView.axaml.cs
+++ b/AvatarExplorer.UI/Views/MainView.axaml.cs
@@ -174,7 +174,12 @@ public partial class MainView : UserControl
 
     private void OnHoverThumbnailVisibilityChanged(bool isVisible)
     {
-        if (isVisible) _hoverWindow.Show();
+        if (isVisible)
+        {
+            _hoverWindow.Show();
+            _hoverWindow.Topmost = false;
+            _hoverWindow.Topmost = true;
+        }
         else _hoverWindow.Hide();
     }
 
@@ -220,6 +225,12 @@ public partial class MainView : UserControl
 
         vm.UpdateHoverThumbnailPosition(GetScreenPosition(e));
         vm.ShowHoverThumbnail(item);
+    }
+
+    private void OnToolTipOpening(object? sender, CancelRoutedEventArgs e)
+    {
+        if (DataContext is not MainViewModel vm) return;
+        if (vm.IsHoverThumbnailVisible) e.Cancel = true;
     }
 
     private void OnItemImagePointerExited(object? sender, PointerEventArgs e)


### PR DESCRIPTION
The item thumbnail Image sits inside the item Button, so hovering over the thumbnail triggered both the hover-thumbnail popup and the Button's ToolTip after 1500ms, causing the two to overlap.

Cancel ToolTip opening in OnToolTipOpening while IsHoverThumbnailVisible is true, and re-assert _hoverWindow.Topmost on show so the popup stays in front of the tooltip layer.