### PR TITLE
feat(items): add implemented sort order with status styling

### DIFF
--- a/AvatarExplorer.Core/Data/Localization/en-US.json
+++ b/AvatarExplorer.Core/Data/Localization/en-US.json
@@ -241,6 +241,7 @@
     "Settings.SortOrder.Options.Author": "Author",
     "Settings.SortOrder.Options.Created": "Created Date",
     "Settings.SortOrder.Options.Updated": "Updated Date",
+    "Settings.SortOrder.Options.Implemented": "Implemented",
     "Settings.SortDirection.Title": "Sort Direction",
     "Settings.SortDirection.Description": "Ascending or descending order",
     "Settings.SortDirection.Options.Ascending": "Ascending",

--- a/AvatarExplorer.Core/Data/Localization/es-ES.json
+++ b/AvatarExplorer.Core/Data/Localization/es-ES.json
@@ -240,6 +240,7 @@
     "Settings.SortOrder.Options.Author": "Autor",
     "Settings.SortOrder.Options.Created": "Fecha de creación",
     "Settings.SortOrder.Options.Updated": "Fecha de actualización",
+    "Settings.SortOrder.Options.Implemented": "Implementado",
     "Settings.SortDirection.Title": "Dirección de clasificación",
     "Settings.SortDirection.Description": "Orden ascendente o descendente",
     "Settings.SortDirection.Options.Ascending": "Ascendente",

--- a/AvatarExplorer.Core/Data/Localization/fr-FR.json
+++ b/AvatarExplorer.Core/Data/Localization/fr-FR.json
@@ -240,6 +240,7 @@
     "Settings.SortOrder.Options.Author": "Auteur",
     "Settings.SortOrder.Options.Created": "Date de création",
     "Settings.SortOrder.Options.Updated": "Date de mise à jour",
+    "Settings.SortOrder.Options.Implemented": "Implémenté",
     "Settings.SortDirection.Title": "Direction du tri",
     "Settings.SortDirection.Description": "Ordre croissant ou décroissant",
     "Settings.SortDirection.Options.Ascending": "Croissant",

--- a/AvatarExplorer.Core/Data/Localization/ja-JP.json
+++ b/AvatarExplorer.Core/Data/Localization/ja-JP.json
@@ -240,6 +240,7 @@
     "Settings.SortOrder.Options.Author": "作者",
     "Settings.SortOrder.Options.Created": "作成日時",
     "Settings.SortOrder.Options.Updated": "更新日時",
+    "Settings.SortOrder.Options.Implemented": "実装済み",
     "Settings.SortDirection.Title": "並び替え方向",
     "Settings.SortDirection.Description": "昇順または降順",
     "Settings.SortDirection.Options.Ascending": "昇順",

--- a/AvatarExplorer.Core/Data/Localization/ko-KR.json
+++ b/AvatarExplorer.Core/Data/Localization/ko-KR.json
@@ -240,6 +240,7 @@
     "Settings.SortOrder.Options.Author": "작성자",
     "Settings.SortOrder.Options.Created": "작성일시",
     "Settings.SortOrder.Options.Updated": "수정일시",
+    "Settings.SortOrder.Options.Implemented": "구현됨",
     "Settings.SortDirection.Title": "정렬 방향",
     "Settings.SortDirection.Description": "오름차순 또는 내림차순",
     "Settings.SortDirection.Options.Ascending": "오름차순",

--- a/AvatarExplorer.Core/Data/Localization/zh-CN.json
+++ b/AvatarExplorer.Core/Data/Localization/zh-CN.json
@@ -240,6 +240,7 @@
     "Settings.SortOrder.Options.Author": "作者",
     "Settings.SortOrder.Options.Created": "创建时间",
     "Settings.SortOrder.Options.Updated": "更新时间",
+    "Settings.SortOrder.Options.Implemented": "已实现",
     "Settings.SortDirection.Title": "排序方向",
     "Settings.SortDirection.Description": "升序或降序",
     "Settings.SortDirection.Options.Ascending": "升序",

--- a/AvatarExplorer.Core/Data/Localization/zh-TW.json
+++ b/AvatarExplorer.Core/Data/Localization/zh-TW.json
@@ -240,6 +240,7 @@
     "Settings.SortOrder.Options.Author": "作者",
     "Settings.SortOrder.Options.Created": "建立時間",
     "Settings.SortOrder.Options.Updated": "更新時間",
+    "Settings.SortOrder.Options.Implemented": "已實裝",
     "Settings.SortDirection.Title": "排序方向",
     "Settings.SortDirection.Description": "升序或降序",
     "Settings.SortDirection.Options.Ascending": "升序",

--- a/AvatarExplorer.Core/Localization/LocalizationKeys.g.cs
+++ b/AvatarExplorer.Core/Localization/LocalizationKeys.g.cs
@@ -389,6 +389,7 @@ public static class Loc
                 public const string Author = "Settings.SortOrder.Options.Author";
                 public const string Created = "Settings.SortOrder.Options.Created";
                 public const string Updated = "Settings.SortOrder.Options.Updated";
+                public const string Implemented = "Settings.SortOrder.Options.Implemented";
             }
         }
         public static class SortDirection

--- a/AvatarExplorer.UI/App.axaml
+++ b/AvatarExplorer.UI/App.axaml
@@ -56,6 +56,15 @@
                     <SolidColorBrush x:Key="Tag.Background" Color="rgba(43,120,191,1.0)"/>
                     <!-- タグの文字色 -->
                     <SolidColorBrush x:Key="Tag.Text" Color="rgba(255,255,255,1.0)"/>
+
+                    <!-- 実装済みボタンの背景 -->
+                    <SolidColorBrush x:Key="Implemented.Background" Color="rgba(0,169,0,0.2)"/>
+                    <!-- 実装済みボタンのホバー背景 -->
+                    <SolidColorBrush x:Key="Implemented.Background.PointerOver" Color="rgba(0,169,0,0.3)"/>
+                    <!-- 未実装ボタンの背景 -->
+                    <SolidColorBrush x:Key="NotImplemented.Background" Color="rgba(200,0,0,0.2)"/>
+                    <!-- 未実装ボタンのホバー背景 -->
+                    <SolidColorBrush x:Key="NotImplemented.Background.PointerOver" Color="rgba(200,0,0,0.3)"/>
                 </ResourceDictionary>
 
                 <ResourceDictionary x:Key="Dark">
@@ -83,6 +92,11 @@
 
                     <SolidColorBrush x:Key="Tag.Background" Color="rgba(43,120,191,1.0)"/>
                     <SolidColorBrush x:Key="Tag.Text" Color="rgba(255,255,255,1.0)"/>
+
+                    <SolidColorBrush x:Key="Implemented.Background" Color="rgba(0,200,0,0.2)"/>
+                    <SolidColorBrush x:Key="Implemented.Background.PointerOver" Color="rgba(0,200,0,0.3)"/>
+                    <SolidColorBrush x:Key="NotImplemented.Background" Color="rgba(200,0,0,0.2)"/>
+                    <SolidColorBrush x:Key="NotImplemented.Background.PointerOver" Color="rgba(200,0,0,0.3)"/>
                 </ResourceDictionary>
 
                 <ResourceDictionary x:Key="{x:Static ui:AppThemeVariants.Sakura}">
@@ -110,6 +124,11 @@
 
                     <SolidColorBrush x:Key="Tag.Background" Color="rgba(209,127,168,1.0)"/>
                     <SolidColorBrush x:Key="Tag.Text" Color="rgba(255,247,250,1.0)"/>
+
+                    <SolidColorBrush x:Key="Implemented.Background" Color="rgba(0,160,80,0.18)"/>
+                    <SolidColorBrush x:Key="Implemented.Background.PointerOver" Color="rgba(0,160,80,0.28)"/>
+                    <SolidColorBrush x:Key="NotImplemented.Background" Color="rgba(200,40,60,0.18)"/>
+                    <SolidColorBrush x:Key="NotImplemented.Background.PointerOver" Color="rgba(200,40,60,0.28)"/>
                 </ResourceDictionary>
 
                 <ResourceDictionary x:Key="{x:Static ui:AppThemeVariants.Mint}">
@@ -137,6 +156,11 @@
 
                     <SolidColorBrush x:Key="Tag.Background" Color="rgba(99,184,146,1.0)"/>
                     <SolidColorBrush x:Key="Tag.Text" Color="rgba(247,255,252,1.0)"/>
+
+                    <SolidColorBrush x:Key="Implemented.Background" Color="rgba(0,160,80,0.18)"/>
+                    <SolidColorBrush x:Key="Implemented.Background.PointerOver" Color="rgba(0,160,80,0.28)"/>
+                    <SolidColorBrush x:Key="NotImplemented.Background" Color="rgba(200,40,60,0.18)"/>
+                    <SolidColorBrush x:Key="NotImplemented.Background.PointerOver" Color="rgba(200,40,60,0.28)"/>
                 </ResourceDictionary>
 
                 <ResourceDictionary x:Key="{x:Static ui:AppThemeVariants.Lavender}">
@@ -164,6 +188,11 @@
 
                     <SolidColorBrush x:Key="Tag.Background" Color="rgba(143,118,221,1.0)"/>
                     <SolidColorBrush x:Key="Tag.Text" Color="rgba(251,249,255,1.0)"/>
+
+                    <SolidColorBrush x:Key="Implemented.Background" Color="rgba(60,170,80,0.18)"/>
+                    <SolidColorBrush x:Key="Implemented.Background.PointerOver" Color="rgba(60,170,80,0.28)"/>
+                    <SolidColorBrush x:Key="NotImplemented.Background" Color="rgba(200,40,60,0.18)"/>
+                    <SolidColorBrush x:Key="NotImplemented.Background.PointerOver" Color="rgba(200,40,60,0.28)"/>
                 </ResourceDictionary>
 
                 <ResourceDictionary x:Key="{x:Static ui:AppThemeVariants.Ocean}">
@@ -191,6 +220,11 @@
 
                     <SolidColorBrush x:Key="Tag.Background" Color="rgba(79,168,204,1.0)"/>
                     <SolidColorBrush x:Key="Tag.Text" Color="rgba(255,255,255,1.0)"/>
+
+                    <SolidColorBrush x:Key="Implemented.Background" Color="rgba(0,180,120,0.2)"/>
+                    <SolidColorBrush x:Key="Implemented.Background.PointerOver" Color="rgba(0,180,120,0.3)"/>
+                    <SolidColorBrush x:Key="NotImplemented.Background" Color="rgba(200,40,60,0.2)"/>
+                    <SolidColorBrush x:Key="NotImplemented.Background.PointerOver" Color="rgba(200,40,60,0.3)"/>
                 </ResourceDictionary>
 
                 <ResourceDictionary x:Key="{x:Static ui:AppThemeVariants.Sunset}">
@@ -218,6 +252,11 @@
 
                     <SolidColorBrush x:Key="Tag.Background" Color="rgba(217,144,79,1.0)"/>
                     <SolidColorBrush x:Key="Tag.Text" Color="rgba(255,251,248,1.0)"/>
+
+                    <SolidColorBrush x:Key="Implemented.Background" Color="rgba(80,160,60,0.18)"/>
+                    <SolidColorBrush x:Key="Implemented.Background.PointerOver" Color="rgba(80,160,60,0.28)"/>
+                    <SolidColorBrush x:Key="NotImplemented.Background" Color="rgba(200,40,60,0.18)"/>
+                    <SolidColorBrush x:Key="NotImplemented.Background.PointerOver" Color="rgba(200,40,60,0.28)"/>
                 </ResourceDictionary>
 
                 <ResourceDictionary x:Key="{x:Static ui:AppThemeVariants.Forest}">
@@ -245,6 +284,11 @@
 
                     <SolidColorBrush x:Key="Tag.Background" Color="rgba(77,148,104,1.0)"/>
                     <SolidColorBrush x:Key="Tag.Text" Color="rgba(248,255,249,1.0)"/>
+
+                    <SolidColorBrush x:Key="Implemented.Background" Color="rgba(0,160,60,0.18)"/>
+                    <SolidColorBrush x:Key="Implemented.Background.PointerOver" Color="rgba(0,160,60,0.28)"/>
+                    <SolidColorBrush x:Key="NotImplemented.Background" Color="rgba(200,40,60,0.18)"/>
+                    <SolidColorBrush x:Key="NotImplemented.Background.PointerOver" Color="rgba(200,40,60,0.28)"/>
                 </ResourceDictionary>
 
                 <ResourceDictionary x:Key="{x:Static ui:AppThemeVariants.Mocha}">
@@ -272,6 +316,11 @@
                     
                     <SolidColorBrush x:Key="Tag.Background" Color="rgba(178,125,98,1.0)"/>
                     <SolidColorBrush x:Key="Tag.Text" Color="rgba(255,255,255,1.0)"/>
+
+                    <SolidColorBrush x:Key="Implemented.Background" Color="rgba(80,140,60,0.18)"/>
+                    <SolidColorBrush x:Key="Implemented.Background.PointerOver" Color="rgba(80,140,60,0.28)"/>
+                    <SolidColorBrush x:Key="NotImplemented.Background" Color="rgba(200,40,60,0.18)"/>
+                    <SolidColorBrush x:Key="NotImplemented.Background.PointerOver" Color="rgba(200,40,60,0.28)"/>
                 </ResourceDictionary>
 
                 <ResourceDictionary x:Key="{x:Static ui:AppThemeVariants.Slate}">
@@ -299,6 +348,11 @@
 
                     <SolidColorBrush x:Key="Tag.Background" Color="rgba(124,146,173,1.0)"/>
                     <SolidColorBrush x:Key="Tag.Text" Color="rgba(255,255,255,1.0)"/>
+
+                    <SolidColorBrush x:Key="Implemented.Background" Color="rgba(60,160,100,0.2)"/>
+                    <SolidColorBrush x:Key="Implemented.Background.PointerOver" Color="rgba(60,160,100,0.3)"/>
+                    <SolidColorBrush x:Key="NotImplemented.Background" Color="rgba(200,40,60,0.2)"/>
+                    <SolidColorBrush x:Key="NotImplemented.Background.PointerOver" Color="rgba(200,40,60,0.3)"/>
                 </ResourceDictionary>
 
             </ResourceDictionary.ThemeDictionaries>
@@ -386,6 +440,38 @@
         <Style Selector="Button.accentbutton:pointerover /template/ ContentPresenter">
             <Setter Property="Background" Value="{DynamicResource Button.AccentBackground.PointerOver}"/>
             <Setter Property="Foreground" Value="{DynamicResource Text.Accent}"/>
+        </Style>
+
+        <Style Selector="Button.implemented">
+            <Setter Property="Background" Value="{DynamicResource Implemented.Background}"/>
+        </Style>
+
+        <Style Selector="Button.implemented:pointerover">
+            <Setter Property="Background" Value="{DynamicResource Implemented.Background.PointerOver}"/>
+        </Style>
+
+        <Style Selector="Button.implemented /template/ ContentPresenter">
+            <Setter Property="Background" Value="{DynamicResource Implemented.Background}"/>
+        </Style>
+
+        <Style Selector="Button.implemented:pointerover /template/ ContentPresenter">
+            <Setter Property="Background" Value="{DynamicResource Implemented.Background.PointerOver}"/>
+        </Style>
+
+        <Style Selector="Button.notimplemented">
+            <Setter Property="Background" Value="{DynamicResource NotImplemented.Background}"/>
+        </Style>
+
+        <Style Selector="Button.notimplemented:pointerover">
+            <Setter Property="Background" Value="{DynamicResource NotImplemented.Background.PointerOver}"/>
+        </Style>
+
+        <Style Selector="Button.notimplemented /template/ ContentPresenter">
+            <Setter Property="Background" Value="{DynamicResource NotImplemented.Background}"/>
+        </Style>
+
+        <Style Selector="Button.notimplemented:pointerover /template/ ContentPresenter">
+            <Setter Property="Background" Value="{DynamicResource NotImplemented.Background.PointerOver}"/>
         </Style>
 
         <Style Selector="Button.pagebutton">

--- a/AvatarExplorer.UI/Models/Sort/ItemSortOrder.cs
+++ b/AvatarExplorer.UI/Models/Sort/ItemSortOrder.cs
@@ -5,7 +5,8 @@ public enum ItemSortOrder
     Title,
     Author,
     CreatedDate,
-    UpdatedDate
+    UpdatedDate,
+    Implemented
 }
 
 public enum SortDirection

--- a/AvatarExplorer.UI/Services/Sort/ItemSortService.cs
+++ b/AvatarExplorer.UI/Services/Sort/ItemSortService.cs
@@ -18,6 +18,7 @@ public static class ItemSortService
             ItemSortOrder.Author => items.OrderBy(i => i.Author, StringComparer.OrdinalIgnoreCase),
             ItemSortOrder.CreatedDate => items.OrderBy(i => i.CreatedDate),
             ItemSortOrder.UpdatedDate => items.OrderBy(i => i.UpdatedDate),
+            ItemSortOrder.Implemented => items.OrderBy(i => removeBrackets ? TextBracketsUtils.RemoveBrackets(i.Title) : i.Title, StringComparer.OrdinalIgnoreCase),
             _ => items.OrderBy(i => i.Title, StringComparer.OrdinalIgnoreCase)
         };
 

--- a/AvatarExplorer.UI/ViewModels/Component/ItemViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Component/ItemViewModel.cs
@@ -21,6 +21,8 @@ public class ItemViewModel : ViewModelBase
 {
     [Reactive] public bool IsVisible { get; set; } = true;
     [Reactive] public bool IsSelected { get; set; } = false;
+    [Reactive] public bool IsImplemented { get; set; } = false;
+    [Reactive] public bool IsNotImplemented { get; set; } = false;
 
     [Reactive] public Bitmap? Thumbnail { get; set; } = null;
     [Reactive] public string Title { get; private set; } = string.Empty;

--- a/AvatarExplorer.UI/ViewModels/MainViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/MainViewModel.cs
@@ -338,7 +338,26 @@ public class MainViewModel : ViewModelBase, IPostInitializable
             var items = navigationables.OfType<Item>().ToList();
             var nonItems = navigationables.Where(i => i is not Item).ToList();
 
-            var sortedItems = ItemSortService.Sort(items, sortOrder, sortDirection, _removeBrackets);
+            IEnumerable<Item> sortedItems;
+            if (sortOrder == ItemSortOrder.Implemented && avatarId != null)
+            {
+                var itemsWithStatus = items.Select(i =>
+                {
+                    var isImplemented = i.ImplementedAvatars.Contains(avatarId);
+                    return (Item: i, IsImplemented: isImplemented);
+                }).ToList();
+
+                var ordered = itemsWithStatus
+                    .OrderByDescending(x => x.IsImplemented)
+                    .ThenBy(x => _removeBrackets ? Utils.TextBracketsUtils.RemoveBrackets(x.Item.Title) : x.Item.Title, StringComparer.OrdinalIgnoreCase);
+
+                sortedItems = (sortDirection == SortDirection.Descending ? ordered.Reverse() : ordered).Select(x => x.Item);
+            }
+            else
+            {
+                sortedItems = ItemSortService.Sort(items, sortOrder, sortDirection, _removeBrackets);
+            }
+
             var sortedNavigationables = sortedItems.Cast<INavigationable>().Concat(nonItems);
 
             _allMainItems = sortedNavigationables
@@ -348,6 +367,9 @@ public class MainViewModel : ViewModelBase, IPostInitializable
                     if (i is Item item)
                     {
                         var status = _itemNavigationService.ResolveAvatarStatusForCurrentAvatar(item, avatarId, commonAvatars);
+                        vm.IsImplemented = avatarId != null && item.ImplementedAvatars.Contains(avatarId);
+                        vm.IsNotImplemented = avatarId != null && !item.ImplementedAvatars.Contains(avatarId);
+
                         if (status.IsOnlyCommon)
                         {
                             var tags = new List<TagViewModel>(item.Tags.Length + 1)

--- a/AvatarExplorer.UI/ViewModels/MainViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/MainViewModel.cs
@@ -314,83 +314,95 @@ public class MainViewModel : ViewModelBase, IPostInitializable
     #region Refresh
     private void Refresh()
     {
+        if (!string.IsNullOrWhiteSpace(_searchManager.ActiveSearchQuery))
+            RefreshSearchResults(_searchManager.ActiveSearchQuery);
+        else
+            RefreshNavigationView();
+    }
+
+    private void RefreshSearchResults(string searchQuery)
+    {
         var sortOrder = (ItemSortOrder)SelectedSortOrder;
         var sortDirection = (SortDirection)SelectedSortDirection;
 
-        if (!string.IsNullOrWhiteSpace(_searchManager.ActiveSearchQuery))
+        _allMainItems = ItemSortService.Sort(
+                _searchManager.SearchItems(searchQuery),
+                sortOrder, sortDirection, _removeBrackets)
+            .Select(CreateItemViewModel)
+            .ToList();
+
+        RightPageInfo.TotalItems = _allMainItems.Count;
+        RightPageInfo.Reset();
+        RefreshMainItems();
+
+        PathSegments = [new PathSegment
         {
-            _allMainItems = ItemSortService.Sort(_searchManager.SearchItems(_searchManager.ActiveSearchQuery), sortOrder, sortDirection, _removeBrackets)
-                .Select(CreateItemViewModel)
-                .ToList();
+            DisplayName = _searchManager.ActiveSearchQueryDisplayText ?? _searchManager.ActiveSearchQuery ?? ""
+        }];
+    }
 
-            RightPageInfo.TotalItems = _allMainItems.Count;
-            RightPageInfo.Reset();
-            RefreshMainItems();
+    private void RefreshNavigationView()
+    {
+        var avatarId = _itemNavigationService.GetCurrentAvatarId();
+        var commonAvatars = _itemGroupService.CommonAvatarRepository.GetAll();
+        var sortOrder = (ItemSortOrder)SelectedSortOrder;
+        var sortDirection = (SortDirection)SelectedSortDirection;
 
-            PathSegments = [new PathSegment { DisplayName = _searchManager.ActiveSearchQueryDisplayText ?? _searchManager.ActiveSearchQuery ?? "" }];
-        }
-        else
+        var navigationables = _itemNavigationService.GetCurrentSelectionView();
+        var items = navigationables.OfType<Item>().ToList();
+        var nonItems = navigationables.Where(i => i is not Item).ToList();
+
+        var sortedItems = SortNavigationItems(items, sortOrder, sortDirection, avatarId);
+        var sortedNavigationables = sortedItems.Cast<INavigationable>().Concat(nonItems);
+
+        _allMainItems = sortedNavigationables
+            .Select(nav => CreateItemViewModelWithStatus(nav, avatarId, commonAvatars))
+            .ToList();
+
+        RightPageInfo.TotalItems = _allMainItems.Count;
+        RefreshMainItems();
+
+        PathSegments = new ObservableCollection<PathSegment>(
+            BuildPathSegments(_itemNavigationService.GetCurrentSelectionNodes().Select(i => i.Value)));
+    }
+
+    private IEnumerable<Item> SortNavigationItems(List<Item> items, ItemSortOrder sortOrder, SortDirection sortDirection, string? avatarId)
+    {
+        if (sortOrder == ItemSortOrder.Implemented && avatarId != null)
         {
-            var avatarId = _itemNavigationService.GetCurrentAvatarId();
-            var commonAvatars = _itemGroupService.CommonAvatarRepository.GetAll();
+            var ordered = items
+                .Select(i => (Item: i, IsImplemented: i.ImplementedAvatars.Contains(avatarId)))
+                .OrderByDescending(x => x.IsImplemented)
+                .ThenBy(x => _removeBrackets ? Utils.TextBracketsUtils.RemoveBrackets(x.Item.Title) : x.Item.Title, StringComparer.OrdinalIgnoreCase);
 
-            var navigationables = _itemNavigationService.GetCurrentSelectionView();
-            var items = navigationables.OfType<Item>().ToList();
-            var nonItems = navigationables.Where(i => i is not Item).ToList();
-
-            IEnumerable<Item> sortedItems;
-            if (sortOrder == ItemSortOrder.Implemented && avatarId != null)
-            {
-                var itemsWithStatus = items.Select(i =>
-                {
-                    var isImplemented = i.ImplementedAvatars.Contains(avatarId);
-                    return (Item: i, IsImplemented: isImplemented);
-                }).ToList();
-
-                var ordered = itemsWithStatus
-                    .OrderByDescending(x => x.IsImplemented)
-                    .ThenBy(x => _removeBrackets ? Utils.TextBracketsUtils.RemoveBrackets(x.Item.Title) : x.Item.Title, StringComparer.OrdinalIgnoreCase);
-
-                sortedItems = (sortDirection == SortDirection.Descending ? ordered.Reverse() : ordered).Select(x => x.Item);
-            }
-            else
-            {
-                sortedItems = ItemSortService.Sort(items, sortOrder, sortDirection, _removeBrackets);
-            }
-
-            var sortedNavigationables = sortedItems.Cast<INavigationable>().Concat(nonItems);
-
-            _allMainItems = sortedNavigationables
-                .Select(i =>
-                {
-                    var vm = CreateItemViewModel(i);
-                    if (i is Item item)
-                    {
-                        var status = _itemNavigationService.ResolveAvatarStatusForCurrentAvatar(item, avatarId, commonAvatars);
-                        vm.IsImplemented = avatarId != null && item.ImplementedAvatars.Contains(avatarId);
-                        vm.IsNotImplemented = avatarId != null && !item.ImplementedAvatars.Contains(avatarId);
-
-                        if (status.IsOnlyCommon)
-                        {
-                            var tags = new List<TagViewModel>(item.Tags.Length + 1)
-                            {
-                                new() { ValueRaw = status.CommonAvatarName, IsCommonAvatar = true }
-                            };
-                            tags.AddRange(vm.Tags);
-                            vm.Tags = tags.ToArray();
-                        }
-                    }
-
-                    return vm;
-                })
-                .ToList();
-
-            RightPageInfo.TotalItems = _allMainItems.Count;
-            RefreshMainItems();
-
-            PathSegments = new ObservableCollection<PathSegment>(
-                BuildPathSegments(_itemNavigationService.GetCurrentSelectionNodes().Select(i => i.Value)));
+            return (sortDirection == SortDirection.Descending ? ordered.Reverse() : ordered).Select(x => x.Item);
         }
+
+        return ItemSortService.Sort(items, sortOrder, sortDirection, _removeBrackets);
+    }
+
+    private ItemViewModel CreateItemViewModelWithStatus(INavigationable nav, string? avatarId, IReadOnlyList<CommonAvatar> commonAvatars)
+    {
+        var vm = CreateItemViewModel(nav);
+
+        if (nav is not Item item) return vm;
+
+        var isImplemented = avatarId != null && item.ImplementedAvatars.Contains(avatarId);
+        vm.IsImplemented = isImplemented;
+        vm.IsNotImplemented = avatarId != null && !isImplemented;
+
+        var status = _itemNavigationService.ResolveAvatarStatusForCurrentAvatar(item, avatarId, commonAvatars);
+        if (status.IsOnlyCommon)
+        {
+            var tags = new List<TagViewModel>(item.Tags.Length + 1)
+            {
+                new() { ValueRaw = status.CommonAvatarName, IsCommonAvatar = true }
+            };
+            tags.AddRange(vm.Tags);
+            vm.Tags = tags.ToArray();
+        }
+
+        return vm;
     }
 
     private void RefreshLeftItems()

--- a/AvatarExplorer.UI/Views/MainView.axaml
+++ b/AvatarExplorer.UI/Views/MainView.axaml
@@ -137,8 +137,7 @@
 
                                             <ItemsControl.ItemTemplate>
                                                 <DataTemplate x:DataType="component:ItemViewModel">
-                                                <!-- TODO: Implemented用のクラスも作るべきかも -->
-                                                    <Button Classes="button" Classes.accentbutton="{Binding IsSelected}" ContextMenu="{Binding ContextMenu}" ToolTip.Tip="{Binding ToolTip}" ToolTip.ToolTipOpening="OnToolTipOpening" HorizontalAlignment="Stretch" VerticalAlignment="Top" CornerRadius="8" Padding="7" Margin="0,0,0,5" Command="{Binding $parent[UserControl].DataContext.SelectLeftItemCommand}" CommandParameter="{Binding}">
+                                                    <Button Classes="button" Classes.accentbutton="{Binding IsSelected}" Classes.implemented="{Binding IsImplemented}" Classes.notimplemented="{Binding IsNotImplemented}" ContextMenu="{Binding ContextMenu}" ToolTip.Tip="{Binding ToolTip}" ToolTip.ToolTipOpening="OnToolTipOpening" HorizontalAlignment="Stretch" VerticalAlignment="Top" CornerRadius="8" Padding="7" Margin="0,0,0,5" Command="{Binding $parent[UserControl].DataContext.SelectLeftItemCommand}" CommandParameter="{Binding}">
                                                         <Grid ColumnDefinitions="Auto,*" ColumnSpacing="10">
                                                             <Border CornerRadius="8" ClipToBounds="true" HorizontalAlignment="Center" VerticalAlignment="Top">
                                                                 <Image Source="{Binding Thumbnail}" Width="{Binding Width}" Height="{Binding Height}" Stretch="Fill" VerticalAlignment="Top" Loaded="OnItemImageLoaded" Unloaded="OnItemImageUnloaded"/>
@@ -218,7 +217,7 @@
 
                                             <ItemsControl.ItemTemplate>
                                                 <DataTemplate x:DataType="component:ItemViewModel">
-                                                    <Button Classes="button" ContextMenu="{Binding ContextMenu}" ToolTip.Tip="{Binding ToolTip}" ToolTip.ToolTipOpening="OnToolTipOpening" HorizontalAlignment="Stretch" VerticalAlignment="Top" CornerRadius="8" Padding="7" Margin="0,0,0,5" Command="{Binding $parent[UserControl].DataContext.SelectRightItemCommand}" CommandParameter="{Binding}" Loaded="OnMainItemButtonLoaded" Unloaded="OnMainItemButtonUnloaded">
+                                                    <Button Classes="button" Classes.implemented="{Binding IsImplemented}" Classes.notimplemented="{Binding IsNotImplemented}" ContextMenu="{Binding ContextMenu}" ToolTip.Tip="{Binding ToolTip}" ToolTip.ToolTipOpening="OnToolTipOpening" HorizontalAlignment="Stretch" VerticalAlignment="Top" CornerRadius="8" Padding="7" Margin="0,0,0,5" Command="{Binding $parent[UserControl].DataContext.SelectRightItemCommand}" CommandParameter="{Binding}" Loaded="OnMainItemButtonLoaded" Unloaded="OnMainItemButtonUnloaded">
                                                         <Grid ColumnDefinitions="Auto,*" ColumnSpacing="10">
                                                             <Border CornerRadius="8" ClipToBounds="true" HorizontalAlignment="Center" VerticalAlignment="Top">
                                                                 <Image Source="{Binding Thumbnail}" Width="{Binding Width}" Height="{Binding Height}" Stretch="Fill" VerticalAlignment="Top" Loaded="OnItemImageLoaded" Unloaded="OnItemImageUnloaded"/>

--- a/AvatarExplorer.UI/Views/Overlays/SettingsOverlay.axaml
+++ b/AvatarExplorer.UI/Views/Overlays/SettingsOverlay.axaml
@@ -39,6 +39,7 @@
                                             <ComboBoxItem Content="{Binding [Settings.SortOrder.Options.Author], Source={x:Static loc:Localizer.Instance}}"/>
                                             <ComboBoxItem Content="{Binding [Settings.SortOrder.Options.Created], Source={x:Static loc:Localizer.Instance}}"/>
                                             <ComboBoxItem Content="{Binding [Settings.SortOrder.Options.Updated], Source={x:Static loc:Localizer.Instance}}"/>
+                                            <ComboBoxItem Content="{Binding [Settings.SortOrder.Options.Implemented], Source={x:Static loc:Localizer.Instance}}"/>
                                         </ComboBox>
                                     </Grid>
                                     </Grid>


### PR DESCRIPTION
Add a new Implemented sort order that places items already implemented for the current avatar at the top.

- add Implemented to ItemSortOrder and handle it in ItemSortService
- sort implemented items first in MainViewModel.Refresh
- add IsImplemented/IsNotImplemented states to ItemViewModel
- style implemented/notimplemented buttons across all 10 themes
- add Settings.SortOrder.Options.Implemented to all 7 locales

Fixes #312