### PR TITLE
fix(ui): update left panel items before refresh when preference changes

### DIFF
--- a/AvatarExplorer.UI/ViewModels/MainViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/MainViewModel.cs
@@ -230,7 +230,11 @@ public class MainViewModel : ViewModelBase, IPostInitializable
         RefreshLeftItems();
         RefreshMainItems();
 
-        if (needsRefresh) Refresh();
+        if (needsRefresh)
+        {
+            UpdateLeftPanelItems((QueryType)SelectedCategory);
+            Refresh();
+        }
     }
 
     private void OnLanguageChanged()


### PR DESCRIPTION
When preferences are updated and needsRefresh is true, update the left panel items before refreshing to ensure the UI reflects the changes.

Fixes #485 