### PR TITLE
refactor(ui): remove redundant UpdateLeftPanelItems call in refresh subscription

### DIFF
--- a/AvatarExplorer.UI/ViewModels/MainViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/MainViewModel.cs
@@ -176,11 +176,7 @@ public class MainViewModel : ViewModelBase, IInitializable, IPostInitializable
                 Observable.FromEvent(h => _itemGroupService.TempAvatarRepository.OnUpdated += h, h => _itemGroupService.TempAvatarRepository.OnUpdated -= h)
             )
             .Throttle(TimeSpan.FromMilliseconds(100))
-            .Subscribe(_ => Dispatcher.UIThread.InvokeAsync(() =>
-            {
-                UpdateLeftPanelItems();
-                Refresh();
-            }));
+            .Subscribe(_ => Dispatcher.UIThread.InvokeAsync(Refresh));
     }
     #endregion
 


### PR DESCRIPTION
Refresh() already internally calls UpdateLeftPanelItems(), making the separate call in the subscription callback redundant.