### PR TITLE
refactor(ui): remove intermediate HoverThumbnailSize reactive property

### DIFF
--- a/AvatarExplorer.UI/ViewModels/MainViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/MainViewModel.cs
@@ -60,7 +60,6 @@ public class MainViewModel : ViewModelBase, IInitializable, IPostInitializable
     [Reactive] public GridLength SidePanelWidth { get; set; } = new(50);
 
     [Reactive] public Bitmap? HoverThumbnailImage { get; set; }
-    [Reactive] public int HoverThumbnailSize { get; set; }
     [Reactive] public bool IsHoverThumbnailVisible { get; set; }
     [Reactive] public PixelPoint HoverThumbnailPosition { get; set; }
     #endregion

--- a/AvatarExplorer.UI/ViewModels/Managers/HoverThumbnailManager.cs
+++ b/AvatarExplorer.UI/ViewModels/Managers/HoverThumbnailManager.cs
@@ -17,7 +17,6 @@ public class HoverThumbnailManager(MainViewModel vm)
         if (!preferences.EnableHoverIconSize) return;
 
         _vm.HoverThumbnailImage = item.Thumbnail;
-        _vm.HoverThumbnailSize = preferences.HoverIconSize;
         _vm.IsHoverThumbnailVisible = true;
     }
 

--- a/AvatarExplorer.UI/Views/MainView.axaml.cs
+++ b/AvatarExplorer.UI/Views/MainView.axaml.cs
@@ -163,9 +163,6 @@ public partial class MainView : UserControl
             case nameof(MainViewModel.HoverThumbnailImage):
                 _hoverWindow.SetImage(vm.HoverThumbnailImage);
                 break;
-            case nameof(MainViewModel.HoverThumbnailSize):
-                _hoverWindow.SetSize(vm.HoverThumbnailSize);
-                break;
             case nameof(MainViewModel.HoverThumbnailPosition):
                 _hoverWindow.Position = vm.HoverThumbnailPosition;
                 break;
@@ -177,6 +174,7 @@ public partial class MainView : UserControl
         if (isVisible)
         {
             _hoverWindow.Show();
+            _hoverWindow.SetSize(UserPreferencesService.Instance.Repository.Settings.HoverIconSize);
             _hoverWindow.Topmost = false;
             _hoverWindow.Topmost = true;
         }


### PR DESCRIPTION
Simplify hover thumbnail size handling by removing the intermediate reactive property and directly reading the size from UserPreferencesService when showing the hover window.