### PR TITLE
fix: garbled characters in sjis zip on Linux

### DIFF
--- a/AvatarExplorer.Core/Services/IO/FileSystemService.cs
+++ b/AvatarExplorer.Core/Services/IO/FileSystemService.cs
@@ -614,10 +614,21 @@ public static class FileSystemService
         using var archive = SharpCompress.Archives.Tar.TarArchive.OpenArchive(filePath);
         await ExtractEntriesAsync(extractDirectoryFolder, archive.Entries);
     }
+    static ArchiveEncoding archiveEncoding
+    {
+        get
+        {
+            if (field is not null) return field;
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+            field = new ArchiveEncoding() { Default = Encoding.GetEncoding("Shift_JIS") };
+            return field;
+        }
+    }
     private static SharpCompress.Readers.ReaderOptions CreateReaderOptions(string? password)
     {
         return new()
         {
+            ArchiveEncoding = archiveEncoding,
             Password = string.IsNullOrEmpty(password) ? null : password,
             LeaveStreamOpen = false
         };


### PR DESCRIPTION
before
<img width="1437" height="784" alt="image" src="https://github.com/user-attachments/assets/76b95a90-234d-4bd3-8c35-2e2249b5b41a" />

after
<img width="1685" height="751" alt="image" src="https://github.com/user-attachments/assets/17f43591-462c-4419-b7ca-d03356d20540" />



おそらく Linux 固有で環境のデフォルトエンコードが UTF-8 だからかと思われ
SharpCompress.Readers.ReaderOptions のフォールバックの部分にとりあえず決め打ちで sjis をねじ込むことによって解決できた。

(より良い実装を考えるならば、インポートの詳細設定の部分でエンコード選択できるようにするべきなのかもしれない)