### PR TITLE
fix(localization): apply user language preference on startup instead of defaulting to index 0

### DIFF
--- a/AvatarExplorer.UI/Localization/Localizer.cs
+++ b/AvatarExplorer.UI/Localization/Localizer.cs
@@ -25,9 +25,12 @@ public class Localizer : INotifyPropertyChanged
         get => _selectedLanguageIndex;
         private set
         {
-            _selectedLanguageIndex = value;
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(string.Empty));
-            LanguageChanged?.Invoke();
+            if (_selectedLanguageIndex != value)
+            {
+                _selectedLanguageIndex = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(string.Empty));
+                LanguageChanged?.Invoke();
+            }
         }
     }
 

--- a/AvatarExplorer.UI/Services/AppInitializer.cs
+++ b/AvatarExplorer.UI/Services/AppInitializer.cs
@@ -18,7 +18,6 @@ public static class AppInitializer
     public static void InitializeLocalization()
     {
         Localizer.Instance.LoadFromFolder("locales");
-        Localizer.Instance.SetLanguage(0);
     }
 
     public static void InitializeContextMenu()

--- a/AvatarExplorer.UI/ViewModels/MainWindowViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/MainWindowViewModel.cs
@@ -129,12 +129,12 @@ public class MainWindowViewModel : ViewModelBase, IInitializable, IPostInitializ
         SingleInstanceService.OnPipeMessageReceived += OnPipeMessageReceived;
         ImageService.ThumbnailCacheWarmupStateChanged += OnThumbnailWarmupChanged;
         AvatarExplorerApp.BackupManager.OnBackupRestored += OnBackupRestored;
+
+        ApplyPreferenceSettings(UserPreferencesService.Instance.Repository.Settings);
+        UpdateWindowTitle();
     }
     public async Task OnInitialized()
     {
-        ApplyPreferenceSettings(UserPreferencesService.Instance.Repository.Settings);
-
-        UpdateWindowTitle();
         CheckForUpdateOnStartup();
     }
 
@@ -166,6 +166,8 @@ public class MainWindowViewModel : ViewModelBase, IInitializable, IPostInitializ
 
     private void ApplyPreferenceSettings(UserPreferences settings)
     {
+        Localizer.Instance.SetLanguage(settings.Language);
+
         if (settings.UseBackgroundImage) SetBackgroundImage(settings.BackgroundImage, settings.BackgroundOpacity);
         else BackgroundImage = null;
 


### PR DESCRIPTION
Previously, the app always called SetLanguage(0) during initialization, ignoring the user's saved language preference. Now it reads the preference from UserPreferencesService and applies it in ApplyPreferenceSettings(). Also added a guard clause to avoid redundant PropertyChanged/LanguageChanged events when the language index hasn't changed.