### PR TITLE
feat: add safe URI parsing with invalid URL validation

### DIFF
--- a/AvatarExplorer.Core/Data/Localization/en-US.json
+++ b/AvatarExplorer.Core/Data/Localization/en-US.json
@@ -232,6 +232,7 @@
     "Error.InitializationFailed": "Failed to initialize the software. Please check the error log.",
     "Error.FetchAllItemThumbnailsFailed": "Bulk thumbnail fetch completed. Success: {0} / Failed: {1} / Total: {2}\nCheck the error log for details.",
     "Error.UnitypackageNotFound": "No Unitypackage found",
+    "Error.InvalidUrl": "Invalid URL",
 
     "Settings.Basic": "Basic",
     "Settings.Language.Title": "Language",

--- a/AvatarExplorer.Core/Data/Localization/es-ES.json
+++ b/AvatarExplorer.Core/Data/Localization/es-ES.json
@@ -231,6 +231,7 @@
     "Error.InitializationFailed": "No se pudo inicializar el software. Consulta el registro de errores.",
     "Error.FetchAllItemThumbnailsFailed": "La obtención masiva de miniaturas se completó. Correctos: {0} / Fallidos: {1} / Total: {2}\nConsulta el registro de errores para más detalles.",
     "Error.UnitypackageNotFound": "No se encontró ningún Unitypackage",
+    "Error.InvalidUrl": "URL inválida",
 
     "Settings.Basic": "Básico",
     "Settings.Language.Title": "Idioma",

--- a/AvatarExplorer.Core/Data/Localization/fr-FR.json
+++ b/AvatarExplorer.Core/Data/Localization/fr-FR.json
@@ -231,6 +231,7 @@
     "Error.InitializationFailed": "Échec de l'initialisation du logiciel. Veuillez consulter le journal d'erreurs.",
     "Error.FetchAllItemThumbnailsFailed": "La récupération groupée des vignettes est terminée. Réussies : {0} / Échouées : {1} / Total : {2}\nConsultez le journal d'erreurs pour plus de détails.",
     "Error.UnitypackageNotFound": "Aucun Unitypackage trouvé",
+    "Error.InvalidUrl": "URL invalide",
 
     "Settings.Basic": "Général",
     "Settings.Language.Title": "Langue",

--- a/AvatarExplorer.Core/Data/Localization/ja-JP.json
+++ b/AvatarExplorer.Core/Data/Localization/ja-JP.json
@@ -231,6 +231,7 @@
     "Error.InitializationFailed": "ソフトウェアの初期化に失敗しました。エラーログを確認してください。",
     "Error.FetchAllItemThumbnailsFailed": "サムネイル一括取得が完了しました。成功: {0}件 / 失敗: {1}件 / 合計: {2}件\n詳細はエラーログを確認してください。",
     "Error.UnitypackageNotFound": "Unitypackageが見つかりませんでした",
+    "Error.InvalidUrl": "無効なURLです",
 
     "Settings.Basic": "基本",
     "Settings.Language.Title": "言語",

--- a/AvatarExplorer.Core/Data/Localization/ko-KR.json
+++ b/AvatarExplorer.Core/Data/Localization/ko-KR.json
@@ -231,6 +231,7 @@
     "Error.InitializationFailed": "소프트웨어 초기화에 실패했습니다. 오류 로그를 확인해 주세요.",
     "Error.FetchAllItemThumbnailsFailed": "썸네일 일괄 가져오기가 완료되었습니다. 성공: {0}개 / 실패: {1}개 / 전체: {2}개\n자세한 내용은 오류 로그를 확인해 주세요.",
     "Error.UnitypackageNotFound": "Unitypackage를 찾을 수 없습니다",
+    "Error.InvalidUrl": "유효하지 않은 URL입니다",
 
     "Settings.Basic": "기본",
     "Settings.Language.Title": "언어",

--- a/AvatarExplorer.Core/Data/Localization/zh-CN.json
+++ b/AvatarExplorer.Core/Data/Localization/zh-CN.json
@@ -231,6 +231,7 @@
     "Error.InitializationFailed": "软件初始化失败。请查看错误日志。",
     "Error.FetchAllItemThumbnailsFailed": "批量获取缩略图完成。成功: {0} 个 / 失败: {1} 个 / 总计: {2} 个\n请查看错误日志了解详情。",
     "Error.UnitypackageNotFound": "未找到Unitypackage",
+    "Error.InvalidUrl": "无效的URL",
 
     "Settings.Basic": "基本",
     "Settings.Language.Title": "语言",

--- a/AvatarExplorer.Core/Data/Localization/zh-TW.json
+++ b/AvatarExplorer.Core/Data/Localization/zh-TW.json
@@ -231,6 +231,7 @@
     "Error.InitializationFailed": "軟體初始化失敗。請檢查錯誤日誌。",
     "Error.FetchAllItemThumbnailsFailed": "批次取得縮圖完成。成功: {0} 個 / 失敗: {1} 個 / 總計: {2} 個\n請查看錯誤日誌以取得詳細資訊。",
     "Error.UnitypackageNotFound": "未找到Unitypackage",
+    "Error.InvalidUrl": "無效的URL",
 
     "Settings.Basic": "基本",
     "Settings.Language.Title": "語言",

--- a/AvatarExplorer.Core/Localization/LocalizationKeys.g.cs
+++ b/AvatarExplorer.Core/Localization/LocalizationKeys.g.cs
@@ -371,6 +371,7 @@ public static class Loc
         public const string InitializationFailed = "Error.InitializationFailed";
         public const string FetchAllItemThumbnailsFailed = "Error.FetchAllItemThumbnailsFailed";
         public const string UnitypackageNotFound = "Error.UnitypackageNotFound";
+        public const string InvalidUrl = "Error.InvalidUrl";
     }
     public static class Settings
     {

--- a/AvatarExplorer.Core/Utils/UriUtils.cs
+++ b/AvatarExplorer.Core/Utils/UriUtils.cs
@@ -1,0 +1,22 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace AvatarExplorer.Core.Utils;
+
+public static class UriUtils
+{
+    public static bool TryParse(string uriString, [NotNullWhen(true)] out Uri? result)
+    {
+        result = null;
+        if (string.IsNullOrWhiteSpace(uriString)) return false;
+
+        try
+        {
+            result = new Uri(uriString);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/AvatarExplorer.UI/Services/System/BLMImportItemService.cs
+++ b/AvatarExplorer.UI/Services/System/BLMImportItemService.cs
@@ -1,5 +1,5 @@
-using System;
 using System.Web;
+using AvatarExplorer.Core.Utils;
 using AvatarExplorer.UI.Models.System;
 
 namespace AvatarExplorer.UI.Services.System;
@@ -8,7 +8,7 @@ public static class BLMImportItemService
 {
     public static BLMImportItemInfo? GetBLMImportItemInfo(string uriString)
     {
-        var uri = new Uri(uriString);
+        if (!UriUtils.TryParse(uriString, out var uri)) return null;
 
         var query = HttpUtility.ParseQueryString(uri.Query);
 

--- a/AvatarExplorer.UI/ViewModels/Overlays/ItemEditorViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/ItemEditorViewModel.cs
@@ -192,8 +192,8 @@ public class ItemEditorViewModel : ViewModelBase
             else if (File.Exists(i)) itemPathType = ItemPathType.File;
             else if (Directory.Exists(i)) itemPathType = ItemPathType.Folder;
 
-            var fileName = itemPathType == ItemPathType.URL
-                ? Path.GetFileName(new Uri(i).GetLeftPart(UriPartial.Path))
+            var fileName = itemPathType == ItemPathType.URL && UriUtils.TryParse(i, out var uri)
+                ? Path.GetFileName(uri.GetLeftPart(UriPartial.Path))
                 : Path.GetFileName(i);
 
             return new ItemPathViewModel(fileName, i, itemPathType);
@@ -354,7 +354,17 @@ public class ItemEditorViewModel : ViewModelBase
         var url = await MainWindowViewModel.Instance.ShowTextDialog(Localizer.Instance[Loc.Dialog.Title.AddUrl]);
         if (string.IsNullOrEmpty(url)) return;
 
-        var fileName = Path.GetFileName(new Uri(url).GetLeftPart(UriPartial.Path));
+        if (!UriUtils.TryParse(url, out var uri))
+        {
+            MainWindowViewModel.Instance.ShowNotification(
+                Localizer.Instance[Loc.Error.Default],
+                Localizer.Instance[Loc.Error.InvalidUrl],
+                Avalonia.Controls.Notifications.NotificationType.Error
+            );
+            return;
+        }
+
+        var fileName = Path.GetFileName(uri.GetLeftPart(UriPartial.Path));
         ItemPaths.Add(new ItemPathViewModel(fileName, url, ItemPathType.URL));
     }
     private async Task FetchBoothData()


### PR DESCRIPTION
- Add UriUtils.TryParse() to prevent UriFormatException crashes

- Use safe parsing in BLMImportItemService and ItemEditorViewModel

- Show error notification when invalid URL is entered in AddUrl

- Add Error.InvalidUrl localization key for all 7 languages