### PR TITLE
fix(settings): use repository Clear() for database reset and localize dialog titles

### DIFF
--- a/AvatarExplorer.Core/Services/System/Repositories/BulkImportPresetRepository.cs
+++ b/AvatarExplorer.Core/Services/System/Repositories/BulkImportPresetRepository.cs
@@ -50,6 +50,14 @@ public class BulkImportPresetRepository
         OnUpdated?.Invoke();
     }
 
+    public void Clear()
+    {
+        _db.Clear();
+
+        Save();
+        OnUpdated?.Invoke();
+    }
+
     public void Save() => _db.Save();
 
     public void MarkAsChanged() => OnUpdated?.Invoke();

--- a/AvatarExplorer.Core/Services/System/Repositories/CommonAvatarRepository.cs
+++ b/AvatarExplorer.Core/Services/System/Repositories/CommonAvatarRepository.cs
@@ -71,6 +71,14 @@ public class CommonAvatarRepository
 
     internal void Add(CommonAvatar avatar) => _db.Add(avatar);
 
+    public void Clear()
+    {
+        _db.Clear();
+
+        Save();
+        OnUpdated?.Invoke();
+    }
+
     public void Save() => _db.Save();
 
     public void MarkAsChanged() => OnUpdated?.Invoke();

--- a/AvatarExplorer.Core/Services/System/Repositories/ItemRepository.cs
+++ b/AvatarExplorer.Core/Services/System/Repositories/ItemRepository.cs
@@ -284,6 +284,14 @@ public class ItemRepository
 
     internal void Add(Item item) => _db.Add(item);
 
+    public void Clear()
+    {
+        _db.Clear();
+
+        Save();
+        OnUpdated?.Invoke();
+    }
+
     public void Save() => _db.Save();
 
     public void MarkAsChanged() => OnUpdated?.Invoke();

--- a/AvatarExplorer.Core/Services/System/Repositories/TempAvatarRepository.cs
+++ b/AvatarExplorer.Core/Services/System/Repositories/TempAvatarRepository.cs
@@ -55,5 +55,13 @@ public class TempAvatarRepository
         OnUpdated?.Invoke();
     }
 
+    public void Clear()
+    {
+        _db.Clear();
+
+        Save();
+        OnUpdated?.Invoke();
+    }
+
     public void MarkAsChanged() => OnUpdated?.Invoke();
 }

--- a/AvatarExplorer.UI/ViewModels/Overlays/SettingsViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/SettingsViewModel.cs
@@ -217,7 +217,7 @@ public class SettingsViewModel : ViewModelBase, IInitializable
 
     private async Task OpenBackgroundImage()
     {
-        var files = await StorageService.OpenFileDialog(TopLevelProvider.Current, "Select Background Image");
+        var files = await StorageService.OpenFileDialog(TopLevelProvider.Current, Localizer.Instance[Loc.Dialog.SelectFilePath]);
         if (files == null || files.Length == 0) return;
 
         BackgroundImagePath = files[0];
@@ -225,7 +225,7 @@ public class SettingsViewModel : ViewModelBase, IInitializable
 
     private async Task OpenItemsFolder()
     {
-        var folders = await StorageService.OpenFolderDialog(TopLevelProvider.Current, "Select Items Folder");
+        var folders = await StorageService.OpenFolderDialog(TopLevelProvider.Current, Localizer.Instance[Loc.Dialog.SelectFolderPath]);
         if (folders == null || folders.Length == 0) return;
 
         ItemsFolderPath = folders[0];
@@ -233,7 +233,7 @@ public class SettingsViewModel : ViewModelBase, IInitializable
 
     private async Task OpenAutoBackupFolder()
     {
-        var folders = await StorageService.OpenFolderDialog(TopLevelProvider.Current, "Select Auto Backup Folder");
+        var folders = await StorageService.OpenFolderDialog(TopLevelProvider.Current, Localizer.Instance[Loc.Dialog.SelectFolderPath]);
         if (folders == null || folders.Length == 0) return;
 
         AutoBackupFolderPath = folders[0];
@@ -293,37 +293,35 @@ public class SettingsViewModel : ViewModelBase, IInitializable
     private async Task ResetItemDatabase()
     {
         var result = await MainWindowViewModel.Instance.ShowYesNoDialog(
-            Localizer.Instance[Loc.Settings.ResetItemDatabase.Title],
-            Localizer.Instance[Loc.Settings.ResetItemDatabase.Description]
+            Localizer.Instance[Loc.Dialog.Confirmation.Default],
+            Localizer.Instance[Loc.Dialog.Confirmation.ResetItemDatabase]
         );
         if (!result) return;
 
-        var dbPath = SystemPath.ItemDatabasePath;
-        if (File.Exists(dbPath)) File.Delete(dbPath);
+        AvatarExplorerApp.Instance.Items.Clear();
+        AvatarExplorerApp.Instance.TempAvatars.Clear();
     }
 
     private async Task ResetCommonAvatarDatabase()
     {
         var result = await MainWindowViewModel.Instance.ShowYesNoDialog(
-            Localizer.Instance[Loc.Settings.ResetCommonAvatarDatabase.Title],
-            Localizer.Instance[Loc.Settings.ResetCommonAvatarDatabase.Description]
+            Localizer.Instance[Loc.Dialog.Confirmation.Default],
+            Localizer.Instance[Loc.Dialog.Confirmation.ResetCommonAvatarDatabase]
         );
         if (!result) return;
 
-        var dbPath = SystemPath.CommonAvatarDatabasePath;
-        if (File.Exists(dbPath)) File.Delete(dbPath);
+        AvatarExplorerApp.Instance.CommonAvatars.Clear();
     }
 
     private async Task ResetBulkImportPresetDatabase()
     {
         var result = await MainWindowViewModel.Instance.ShowYesNoDialog(
-            Localizer.Instance[Loc.Settings.ResetBulkImportPresetDatabase.Title],
-            Localizer.Instance[Loc.Settings.ResetBulkImportPresetDatabase.Description]
+            Localizer.Instance[Loc.Dialog.Confirmation.Default],
+            Localizer.Instance[Loc.Dialog.Confirmation.ResetBulkImportPresetDatabase]
         );
         if (!result) return;
 
-        var dbPath = SystemPath.BulkImportPresetDatabasePath;
-        if (File.Exists(dbPath)) File.Delete(dbPath);
+        AvatarExplorerApp.Instance.BulkImportPresets.Clear();
     }
 
     private void ShowErrorLog()


### PR DESCRIPTION
- Add Clear() method to Item, CommonAvatar, BulkImportPreset, TempAvatar repositories

- Replace file deletion with repository.Clear() for proper database reset

- Use localized strings for folder/file dialog titles in settings

- Clear TempAvatars when resetting item database