### PR TITLE
refactor(repositories): extract base classes and rename INavigationable to IIdentifiable

### DIFF
--- a/AvatarExplorer.Core/Interfaces/Database/IDatabaseItem.cs
+++ b/AvatarExplorer.Core/Interfaces/Database/IDatabaseItem.cs
@@ -1,6 +1,6 @@
 namespace AvatarExplorer.Core.Interfaces.Database;
 
-internal interface IDatabaseItem
+public interface IDatabaseItem
 {
     string Id { get; }
 }

--- a/AvatarExplorer.Core/Interfaces/IIdentifiable.cs
+++ b/AvatarExplorer.Core/Interfaces/IIdentifiable.cs
@@ -1,6 +1,6 @@
 namespace AvatarExplorer.Core.Interfaces;
 
-public interface INavigationable
+public interface IIdentifiable
 {
      string Identifier { get; }
 }

--- a/AvatarExplorer.Core/Interfaces/IRepository.cs
+++ b/AvatarExplorer.Core/Interfaces/IRepository.cs
@@ -1,0 +1,13 @@
+namespace AvatarExplorer.Core.Interfaces;
+
+public interface IRepository<T> where T : class, IIdentifiable
+{
+    event Action? OnUpdated;
+    IReadOnlyList<T> GetAll();
+    T? Get(string identifier);
+    void Load();
+    void Remove(string identifier);
+    void Save();
+    void Clear();
+    void MarkAsChanged();
+}

--- a/AvatarExplorer.Core/Interfaces/ISettingsRepository.cs
+++ b/AvatarExplorer.Core/Interfaces/ISettingsRepository.cs
@@ -1,0 +1,10 @@
+namespace AvatarExplorer.Core.Interfaces;
+
+public interface ISettingsRepository<T> where T : class, new()
+{
+    T Settings { get; }
+    event Action<T>? OnSettingsChanged;
+    void Load(string? path = null);
+    void Update(T settings);
+    void Save();
+}

--- a/AvatarExplorer.Core/Interfaces/ISettingsRepository.cs
+++ b/AvatarExplorer.Core/Interfaces/ISettingsRepository.cs
@@ -4,7 +4,7 @@ public interface ISettingsRepository<T> where T : class, new()
 {
     T Settings { get; }
     event Action<T>? OnSettingsChanged;
-    void Load(string? path = null);
+    void Load();
     void Update(T settings);
     void Save();
 }

--- a/AvatarExplorer.Core/Models/Items/Author.cs
+++ b/AvatarExplorer.Core/Models/Items/Author.cs
@@ -2,7 +2,7 @@
 
 namespace AvatarExplorer.Core.Models.Items;
 
-public class Author : INavigationable
+public class Author : IIdentifiable
 {
     public string Name { get; set; } = string.Empty;
     public int ItemCount { get; set; } = 0;

--- a/AvatarExplorer.Core/Models/Items/Avatar.cs
+++ b/AvatarExplorer.Core/Models/Items/Avatar.cs
@@ -10,13 +10,13 @@ public enum AvatarType
     TempAvatar
 }
 
-public class Avatar : INavigationable
+public class Avatar : IIdentifiable
 {
     public AvatarType Type { get; private set; } = AvatarType.None;
-    public INavigationable Item { get; }
+    public IIdentifiable Item { get; }
     public bool RawIdentifier { get; } // avatar:を付けるかどうかです
 
-    public Avatar(INavigationable navigationable, bool rawIdentifier = false)
+    public Avatar(IIdentifiable navigationable, bool rawIdentifier = false)
     {
         Item = navigationable;
         RawIdentifier = rawIdentifier;

--- a/AvatarExplorer.Core/Models/Items/BulkImportPreset.cs
+++ b/AvatarExplorer.Core/Models/Items/BulkImportPreset.cs
@@ -4,7 +4,7 @@ using AvatarExplorer.Core.Interfaces;
 
 namespace AvatarExplorer.Core.Models.Items;
 
-public class BulkImportPreset(string presetName) : AbstractDatabaseItem, INavigationable
+public class BulkImportPreset(string presetName) : AbstractDatabaseItem, IIdentifiable
 {
     [JsonInclude] public string PresetName { get; private set; } = presetName;
     [JsonInclude] public ImmutableArray<BulkImportItem> Items { get; private set; } = [];

--- a/AvatarExplorer.Core/Models/Items/CommonAvatar.cs
+++ b/AvatarExplorer.Core/Models/Items/CommonAvatar.cs
@@ -4,7 +4,7 @@ using AvatarExplorer.Core.Interfaces;
 
 namespace AvatarExplorer.Core.Models.Items;
 
-public class CommonAvatar(string groupName) : AbstractDatabaseItem, INavigationable
+public class CommonAvatar(string groupName) : AbstractDatabaseItem, IIdentifiable
 {
     [JsonInclude] public string GroupName { get; private set; } = groupName;
     [JsonInclude] public ImmutableArray<string> Avatars { get; private set; } = [];

--- a/AvatarExplorer.Core/Models/Items/Folder.cs
+++ b/AvatarExplorer.Core/Models/Items/Folder.cs
@@ -2,7 +2,7 @@ using AvatarExplorer.Core.Interfaces;
 
 namespace AvatarExplorer.Core.Models.Items;
 
-public class Folder(string identifier, string? path = null) : INavigationable
+public class Folder(string identifier, string? path = null) : IIdentifiable
 {
     public string Title { get; set; } = string.Empty;
     public bool TitleLocalizable { get; set; } = false;

--- a/AvatarExplorer.Core/Models/Items/Item.cs
+++ b/AvatarExplorer.Core/Models/Items/Item.cs
@@ -5,7 +5,7 @@ using AvatarExplorer.Core.Interfaces;
 
 namespace AvatarExplorer.Core.Models.Items;
 
-public class Item : AbstractDatabaseItem, INavigationable
+public class Item : AbstractDatabaseItem, IIdentifiable
 {
     [JsonInclude] public string Title { get; private set; } = string.Empty;
     [JsonInclude] public string Author { get; private set; } = string.Empty;

--- a/AvatarExplorer.Core/Models/Items/ItemCategory.cs
+++ b/AvatarExplorer.Core/Models/Items/ItemCategory.cs
@@ -4,7 +4,7 @@ using AvatarExplorer.Core.Interfaces;
 
 namespace AvatarExplorer.Core.Models.Items;
 
-public record ItemCategory : INavigationable
+public record ItemCategory : IIdentifiable
 {
     public ItemType Type { get; init; } = ItemType.None;
     public string CustomCategory { get; init; } = string.Empty;

--- a/AvatarExplorer.Core/Models/Items/ItemFile.cs
+++ b/AvatarExplorer.Core/Models/Items/ItemFile.cs
@@ -3,7 +3,7 @@ using AvatarExplorer.Core.Utils;
 
 namespace AvatarExplorer.Core.Models.Items;
 
-public class ItemFile(string folderPath, string filePath) : INavigationable
+public class ItemFile(string folderPath, string filePath) : IIdentifiable
 {
     public string ParentFolderPath { get; } = folderPath;
     public string ParentFolderName { get; } = Path.GetFileName(folderPath) ?? string.Empty;

--- a/AvatarExplorer.Core/Models/Items/TempAvatar.cs
+++ b/AvatarExplorer.Core/Models/Items/TempAvatar.cs
@@ -3,7 +3,7 @@ using AvatarExplorer.Core.Interfaces;
 
 namespace AvatarExplorer.Core.Models.Items;
 
-public class TempAvatar(string avatarName) : AbstractDatabaseItem, INavigationable
+public class TempAvatar(string avatarName) : AbstractDatabaseItem, IIdentifiable
 {
     [JsonInclude]  public string AvatarName { get; private set; } = avatarName;
 

--- a/AvatarExplorer.Core/Services/Database/DatabaseManager.cs
+++ b/AvatarExplorer.Core/Services/Database/DatabaseManager.cs
@@ -3,7 +3,7 @@ using AvatarExplorer.Core.Services.IO;
 
 namespace AvatarExplorer.Core.Services.Database;
 
-internal class DatabaseManager<T>(string databaseFilePath)
+public class DatabaseManager<T>(string databaseFilePath)
     where T : class, IDatabaseItem
 {
     public string DatabaseFilePath { get; } = databaseFilePath;
@@ -17,25 +17,13 @@ internal class DatabaseManager<T>(string databaseFilePath)
 
     public T? GetById(string? id) => id == null ? null : _items.FirstOrDefault(i => i.Id == id);
 
-    public void Add(T item, bool save = true)
-    {
-        _items.Add(item);
-        if (save) Save();
-    }
+    public void Add(T item) => _items.Add(item);
 
-    public void AddRange(IEnumerable<T> items, bool save = true)
-    {
-        _items.AddRange(items);
-        if (save) Save();
-    }
+    public void AddRange(IEnumerable<T> items) => _items.AddRange(items);
 
-    public bool Remove(string id, bool save = true)
-    {
-        var result = _items.RemoveAll(i => i.Id == id) > 0;
-        if (save) Save();
-        return result;
-    }
+    public bool Remove(string id) => _items.RemoveAll(i => i.Id == id) > 0;
 
     public void ReplaceAll(IEnumerable<T> items) => _items = items.ToList();
+
     public void Clear() => _items.Clear();
 }

--- a/AvatarExplorer.Core/Services/Database/DatabaseManager.cs
+++ b/AvatarExplorer.Core/Services/Database/DatabaseManager.cs
@@ -11,7 +11,7 @@ public class DatabaseManager<T>(string databaseFilePath)
     private List<T> _items = [];
     public IReadOnlyList<T> Items => _items;
 
-    public void Load(string? path = null) => ReplaceAll(JsonFileManager<IEnumerable<T>>.Load(path ?? DatabaseFilePath) ?? []);
+    public void Load() => ReplaceAll(JsonFileManager<IEnumerable<T>>.Load(DatabaseFilePath) ?? []);
 
     public void Save() => JsonFileManager<IEnumerable<T>>.Save(_items, DatabaseFilePath);
 

--- a/AvatarExplorer.Core/Services/Items/ItemNavigationService.cs
+++ b/AvatarExplorer.Core/Services/Items/ItemNavigationService.cs
@@ -24,7 +24,7 @@ public class ItemNavigationService
     private readonly SelectionState _state = new();
     private readonly Dictionary<string, string> _pathCache = new();
 
-    private readonly Dictionary<string, Func<string, INavigationable[]>> _handlers;
+    private readonly Dictionary<string, Func<string, IIdentifiable[]>> _handlers;
 
     public event Action<string>? FileOpenRequested = null;
 
@@ -128,15 +128,15 @@ public class ItemNavigationService
     public string? ResolveFolderPath(string state) => TryParseState(state, out _, out var hash) ? ResolvePath(hash) : null;
     public string? ResolveFilePath(string state) => TryParseState(state, out _, out var hash) ? ResolvePath(hash) : null;
 
-    public INavigationable[] GetCurrentSelectionView()
+    public IIdentifiable[] GetCurrentSelectionView()
     {
         var state = _state.Current?.Value;
-        if (state == null) return _items.ItemRepository.GetAll().ToArray<INavigationable>();
+        if (state == null) return _items.ItemRepository.GetAll().ToArray<IIdentifiable>();
         if (!TryParseState(state, out var key, out _)) return [];
         return _handlers.TryGetValue(key, out var func) ? func(state) : [];
     }
 
-    private INavigationable[] HandleRoot(string state)
+    private IIdentifiable[] HandleRoot(string state)
     {
         if (!TryParseState(state, out var prefix, out var value)) return [];
 
@@ -159,10 +159,10 @@ public class ItemNavigationService
                 TitleLocalizable = isLocalizable,
                 ItemCount = i.Value.Count
             };
-        }).ToArray<INavigationable>();
+        }).ToArray<IIdentifiable>();
     }
 
-    private INavigationable[] HandleCategory(string state)
+    private IIdentifiable[] HandleCategory(string state)
     {
         if (!TryParseState(state, out var prefix, out var value)) return [];
 
@@ -180,7 +180,7 @@ public class ItemNavigationService
         return items.Where(i => i.IsCategoryMatch(state)).ToArray();
     }
 
-    private INavigationable[] HandleItem(string state)
+    private IIdentifiable[] HandleItem(string state)
     {
         var itemFiles = PopulatePathCache(state);
 
@@ -193,10 +193,10 @@ public class ItemNavigationService
                 TitleLocalizable = false,
                 ItemCount = i.Count()
             };
-        }).ToArray<INavigationable>();
+        }).ToArray<IIdentifiable>();
     }
 
-    private INavigationable[] HandleFolder(string state)
+    private IIdentifiable[] HandleFolder(string state)
     {
         if (!TryParseState(state, out _, out var hash)) return [];
 
@@ -219,10 +219,10 @@ public class ItemNavigationService
                 TitleLocalizable = localizationKey != null,
                 ItemCount = i.Value.Count
             };
-        }).ToArray<INavigationable>();
+        }).ToArray<IIdentifiable>();
     }
 
-    private INavigationable[] HandleExtension(string state)
+    private IIdentifiable[] HandleExtension(string state)
     {
         if (!TryParseState(state, out _, out var categoryRaw)) return [];
 

--- a/AvatarExplorer.Core/Services/System/ItemGroupService.cs
+++ b/AvatarExplorer.Core/Services/System/ItemGroupService.cs
@@ -51,7 +51,7 @@ public class ItemGroupService
         _tempAvatars.OnUpdated += TempAvatarUpdated;
     }
 
-    public List<INavigationable> GetQueryFilters(QueryType type)
+    public List<IIdentifiable> GetQueryFilters(QueryType type)
     {
         return type switch
         {
@@ -61,9 +61,9 @@ public class ItemGroupService
             _ => []
         };
     }
-    public List<INavigationable> GetAvatars(bool includeCommonAvatar = false, bool includeTempAvatar = false, bool rawIdentifier = false)
+    public List<IIdentifiable> GetAvatars(bool includeCommonAvatar = false, bool includeTempAvatar = false, bool rawIdentifier = false)
     {
-        var avatars = new List<INavigationable>();
+        var avatars = new List<IIdentifiable>();
 
         if (includeCommonAvatar) avatars.AddRange(_commonAvatars.GetAll());
         avatars.AddRange(_items.GetAll().Where(i => i.Category.Type == ItemType.Avatar));
@@ -71,9 +71,9 @@ public class ItemGroupService
 
         return avatars
             .Select(i => new Avatar(i, rawIdentifier))
-            .ToList<INavigationable>();
+            .ToList<IIdentifiable>();
     }
-    public List<INavigationable> GetAuthors()
+    public List<IIdentifiable> GetAuthors()
     {
         return _items.GetAll()
             .GroupBy(i => i.Author)
@@ -83,9 +83,9 @@ public class ItemGroupService
                 ItemCount = i.Count()
             })
             .OrderBy(i => i.Name)
-            .ToList<INavigationable>();
+            .ToList<IIdentifiable>();
     }
-    public List<INavigationable> GetCategoryFolders(bool includeEmptyCategory = false, bool includeAllCategory = false)
+    public List<IIdentifiable> GetCategoryFolders(bool includeEmptyCategory = false, bool includeAllCategory = false)
     {
         var categories = new List<Folder>();
         
@@ -138,7 +138,7 @@ public class ItemGroupService
             };
         }));
 
-        return categories.ToList<INavigationable>();
+        return categories.ToList<IIdentifiable>();
     }
     public List<Item> GetItemsFromAvatar(string id)
     {

--- a/AvatarExplorer.Core/Services/System/Repositories/BulkImportPresetRepository.cs
+++ b/AvatarExplorer.Core/Services/System/Repositories/BulkImportPresetRepository.cs
@@ -1,42 +1,22 @@
 using AvatarExplorer.Core.Data.Paths;
 using AvatarExplorer.Core.Models.Items;
-using AvatarExplorer.Core.Services.Database;
 using AvatarExplorer.Core.Services.IO;
 
 namespace AvatarExplorer.Core.Services.System.Repositories;
 
-public class BulkImportPresetRepository
+public class BulkImportPresetRepository : RepositoryBase<BulkImportPreset>
 {
-    private readonly DatabaseManager<BulkImportPreset> _db = new(SystemPath.BulkImportPresetDatabasePath);
+    public BulkImportPresetRepository() : base(SystemPath.BulkImportPresetDatabasePath) { }
 
-    /// <summary>
-    /// アイテムが追加・更新・削除された際に発火します。
-    /// </summary>
-    public event Action? OnUpdated;
-
-    public void Load()
+    public override void Load()
     {
         DatabaseMigrationService.Migrate(
-            _db.DatabaseFilePath,
+            Db.DatabaseFilePath,
             DatabaseMigrations.BulkImportPresetVersion,
             DatabaseMigrations.ApplyBulkImportPresetMigration);
 
-        _db.Load();
-        OnUpdated?.Invoke();
-    }
-
-    public IReadOnlyList<BulkImportPreset> GetAll() => _db.Items;
-    public BulkImportPreset? Get(string identifier) => _db.Items.FirstOrDefault(i => i.Identifier == identifier);
-
-    public void Remove(string identifier)
-    {
-        var item = Get(identifier);
-        if (item == null) return;
-
-        _db.Remove(item.Id);
-        Save();
-
-        OnUpdated?.Invoke();
+        Db.Load();
+        InvokeUpdated();
     }
 
     public void Create(string presetName, BulkImportItem[] items)
@@ -44,21 +24,6 @@ public class BulkImportPresetRepository
         var group = new BulkImportPreset(presetName);
         group.UpdateItems(items);
 
-        _db.Add(group);
-        Save();
-
-        OnUpdated?.Invoke();
+        Add(group);
     }
-
-    public void Clear()
-    {
-        _db.Clear();
-
-        Save();
-        OnUpdated?.Invoke();
-    }
-
-    public void Save() => _db.Save();
-
-    public void MarkAsChanged() => OnUpdated?.Invoke();
 }

--- a/AvatarExplorer.Core/Services/System/Repositories/CommonAvatarRepository.cs
+++ b/AvatarExplorer.Core/Services/System/Repositories/CommonAvatarRepository.cs
@@ -1,50 +1,27 @@
 using AvatarExplorer.Core.Data.Paths;
 using AvatarExplorer.Core.Models.Items;
-using AvatarExplorer.Core.Services.Database;
 using AvatarExplorer.Core.Services.IO;
 
 namespace AvatarExplorer.Core.Services.System.Repositories;
 
-public class CommonAvatarRepository
+public class CommonAvatarRepository : RepositoryBase<CommonAvatar>
 {
-    private readonly DatabaseManager<CommonAvatar> _db = new(SystemPath.CommonAvatarDatabasePath);
+    public CommonAvatarRepository() : base(SystemPath.CommonAvatarDatabasePath) { }
 
-    /// <summary>
-    /// CommonAvatar が追加・更新・削除された際に発火します。
-    /// </summary>
-    public event Action? OnUpdated;
-
-    public void Load()
+    public override void Load()
     {
         DatabaseMigrationService.Migrate(
-            _db.DatabaseFilePath,
+            Db.DatabaseFilePath,
             DatabaseMigrations.CommonAvatarVersion,
             DatabaseMigrations.ApplyCommonAvatarMigration);
 
-        _db.Load();
-        OnUpdated?.Invoke();
-    }
-
-    public IReadOnlyList<CommonAvatar> GetAll() => _db.Items;
-    public CommonAvatar? Get(string identifier) => _db.Items.FirstOrDefault(i => i.Identifier == identifier);
-
-    public void Remove(string identifier)
-    {
-        var group = Get(identifier);
-        if (group == null) return;
-
-        _db.Remove(group.Id);
-        Save();
-
-        OnUpdated?.Invoke();
+        Db.Load();
+        InvokeUpdated();
     }
 
     public void Create(string groupName)
     {
-        _db.Add(new(groupName));
-        Save();
-
-        OnUpdated?.Invoke();
+        Add(new(groupName));
     }
 
     public void UpdateAvatars(string groupId, IEnumerable<string> avatars)
@@ -54,10 +31,9 @@ public class CommonAvatarRepository
 
         group.UpdateAvatars(avatars);
         Save();
-
-        OnUpdated?.Invoke();
+        InvokeUpdated();
     }
-    
+
     public void RenameGroup(string groupId, string newName)
     {
         var group = Get(groupId);
@@ -65,21 +41,6 @@ public class CommonAvatarRepository
 
         group.UpdateGroupName(newName);
         Save();
-
-        OnUpdated?.Invoke();
+        InvokeUpdated();
     }
-
-    internal void Add(CommonAvatar avatar) => _db.Add(avatar);
-
-    public void Clear()
-    {
-        _db.Clear();
-
-        Save();
-        OnUpdated?.Invoke();
-    }
-
-    public void Save() => _db.Save();
-
-    public void MarkAsChanged() => OnUpdated?.Invoke();
 }

--- a/AvatarExplorer.Core/Services/System/Repositories/ItemRepository.cs
+++ b/AvatarExplorer.Core/Services/System/Repositories/ItemRepository.cs
@@ -1,7 +1,6 @@
 using AvatarExplorer.Core.Data.Paths;
 using AvatarExplorer.Core.Extensions;
 using AvatarExplorer.Core.Models.Items;
-using AvatarExplorer.Core.Services.Database;
 using AvatarExplorer.Core.Services.IO;
 using AvatarExplorer.Core.Services.Network;
 using AvatarExplorer.Core.Utils;
@@ -9,30 +8,24 @@ using ErrorOr;
 
 namespace AvatarExplorer.Core.Services.System.Repositories;
 
-public class ItemRepository
+public class ItemRepository : RepositoryBase<Item>
 {
-    private readonly DatabaseManager<Item> _db = new(SystemPath.ItemDatabasePath);
+    public ItemRepository() : base(SystemPath.ItemDatabasePath) { }
 
-    /// <summary>
-    /// アイテムが追加・更新・削除された際に発火します。
-    /// </summary>
-    public event Action? OnUpdated;
-
-    public void Load()
+    public override void Load()
     {
         DatabaseMigrationService.Migrate(
-            _db.DatabaseFilePath,
+            Db.DatabaseFilePath,
             DatabaseMigrations.ItemVersion,
             (root, version) => DatabaseMigrations.ApplyItemMigration(root, version, AvatarExplorerApp.Instance.RuntimeSettings.Settings.DataRootDirectory));
 
-        _db.Load();
-        OnUpdated?.Invoke();
+        Db.Load();
+        InvokeUpdated();
     }
 
-    public IReadOnlyList<Item> GetAll() => _db.Items;
-    public Item? Get(string identifier) => _db.Items.FirstOrDefault(i => i.Identifier == identifier);
+    public override void Remove(string identifier) => Remove(identifier, removeFolder: false);
 
-    public void Remove(string identifier, bool removeFolder = false)
+    public void Remove(string identifier, bool removeFolder)
     {
         var item = Get(identifier);
         if (item == null) return;
@@ -42,10 +35,9 @@ public class ItemRepository
             FileSystemService.DeleteDirectory(item.ItemPath);
         }
 
-        _db.Remove(item.Id);
-
-        Save();
-        OnUpdated?.Invoke();
+        Db.Remove(item.Id);
+        Db.Save();
+        InvokeUpdated();
     }
 
     public async Task<Item> Create(ItemCreationContext context)
@@ -64,17 +56,15 @@ public class ItemRepository
         item.UpdateSupportedAvatars(context.SupportedAvatars);
         item.UpdateTags(context.Tags);
 
-        _db.Add(item);
-
         var destPath = Path.Combine(SystemPath.ItemThumbnailsFolderPath, item.Id);
         var downloaded = await context.FetchThumbnailAsync(destPath, overwrite: true);
         if (downloaded) item.UpdateThumbnailFileName(item.Id);
 
-        Save();
-        OnUpdated?.Invoke();
+        Add(item);
 
         return item;
     }
+
     public async Task<bool> Update(string identifier, ItemEditContext context)
     {
         var item = Get(identifier);
@@ -103,7 +93,7 @@ public class ItemRepository
         item.UpdateTimestamp(now);
 
         Save();
-        OnUpdated?.Invoke();
+        InvokeUpdated();
 
         return true;
     }
@@ -119,18 +109,17 @@ public class ItemRepository
                 if (item.BoothId != -1)
                     folderName = item.BoothId.ToString();
                 else
-                    folderName = item.Id; // 最後の手段
+                    folderName = item.Id;
             }
 
             return FileSystemService.GetUniquePath(dataRootDirectory, folderName, true);
         }
-        
+
         var item = Get(identifier);
         if (item == null) return Error.NotFound(description: "Item not found.");
 
         var settings = AvatarExplorerApp.Instance.RuntimeSettings.Settings;
 
-        // Zipを展開する必要がある時はこれが使われる
         var defaultExtractPath = string.IsNullOrEmpty(item.ItemPath) ? GetSafePath(item, settings.DataRootDirectory) : item.ItemPath;
         var result = await FileSystemService.ExtractItemPaths(defaultExtractPath, paths, shouldLinkToOriginal, settings.MaxDegreeOfParallelism, settings.RemoveOriginal);
         if (result.IsError) return Error.Failure(description: "Failed to extract item paths.");
@@ -139,7 +128,7 @@ public class ItemRepository
         item.UpdateItemPaths(result.Value.FolderPaths);
 
         Save();
-        OnUpdated?.Invoke();
+        InvokeUpdated();
 
         return result;
     }
@@ -168,15 +157,14 @@ public class ItemRepository
             .ThenBy(kvp => kvp.Key.StartsWith("type:") ? int.Parse(kvp.Key[5..]) : 0)
             .ThenBy(kvp => kvp.Key);
     }
+
     public List<ItemFile> EnumerateItemFiles(string id)
     {
-        // Root
         var item = Get(id);
         if (item == null) return [];
 
         var files = new List<ItemFile>();
 
-        // Root
         var root = item.ItemPath;
         foreach (var rootFile in FileSystemService.EnumerateFiles(root, isRecursive: false))
             files.Add(new(root, rootFile));
@@ -188,7 +176,6 @@ public class ItemRepository
                     files.Add(new(rootFolder, rootFolderFile));
         }
 
-        // Other Folders
         foreach (var otherFolder in item.ItemPaths)
             foreach (var otherFile in FileSystemService.EnumerateFiles(otherFolder, isRecursive: true))
                 files.Add(new(otherFolder, otherFile));
@@ -209,7 +196,7 @@ public class ItemRepository
         item.UpdateTimestamp(DatetimeUtils.GetCurrentUnixTime());
 
         Save();
-        OnUpdated?.Invoke();
+        InvokeUpdated();
 
         return Result.Success;
     }
@@ -223,7 +210,7 @@ public class ItemRepository
             .ForEach(i => i.UpdateCategory(newCategory));
 
         Save();
-        OnUpdated?.Invoke();
+        InvokeUpdated();
     }
 
     public async Task<ErrorOr<Success>> FetchThumbnailFromBooth(string identifier)
@@ -246,7 +233,7 @@ public class ItemRepository
         item.UpdateTimestamp(DatetimeUtils.GetCurrentUnixTime());
 
         Save();
-        OnUpdated?.Invoke();
+        InvokeUpdated();
 
         return Result.Success;
     }
@@ -260,7 +247,7 @@ public class ItemRepository
         targetItems.ForEach(i => i.UpdateCategory(targetCategory));
 
         Save();
-        OnUpdated?.Invoke();
+        InvokeUpdated();
     }
 
     public void ValidateAndAutoFixItemType(bool avatarExist)
@@ -278,21 +265,7 @@ public class ItemRepository
             }
 
             Save();
-            OnUpdated?.Invoke();
+            InvokeUpdated();
         }
     }
-
-    internal void Add(Item item) => _db.Add(item);
-
-    public void Clear()
-    {
-        _db.Clear();
-
-        Save();
-        OnUpdated?.Invoke();
-    }
-
-    public void Save() => _db.Save();
-
-    public void MarkAsChanged() => OnUpdated?.Invoke();
 }

--- a/AvatarExplorer.Core/Services/System/Repositories/RepositoryBase.cs
+++ b/AvatarExplorer.Core/Services/System/Repositories/RepositoryBase.cs
@@ -1,0 +1,47 @@
+using AvatarExplorer.Core.Interfaces;
+using AvatarExplorer.Core.Interfaces.Database;
+using AvatarExplorer.Core.Services.Database;
+
+namespace AvatarExplorer.Core.Services.System.Repositories;
+
+public abstract class RepositoryBase<T>(string dbPath) : IRepository<T> where T : class, IIdentifiable, IDatabaseItem
+{
+    protected readonly DatabaseManager<T> Db = new(dbPath);
+    public event Action? OnUpdated;
+
+    public IReadOnlyList<T> GetAll() => Db.Items;
+
+    public T? Get(string identifier) => Db.Items.FirstOrDefault(i => i.Identifier == identifier);
+
+    public virtual void Remove(string identifier)
+    {
+        var item = Get(identifier);
+        if (item == null) return;
+
+        Db.Remove(item.Id);
+        Db.Save();
+        OnUpdated?.Invoke();
+    }
+
+    public void Save() => Db.Save();
+
+    public void Clear()
+    {
+        Db.Clear();
+        Db.Save();
+        OnUpdated?.Invoke();
+    }
+
+    public void MarkAsChanged() => OnUpdated?.Invoke();
+
+    public abstract void Load();
+
+    protected void InvokeUpdated() => OnUpdated?.Invoke();
+
+    public void Add(T item)
+    {
+        Db.Add(item);
+        Db.Save();
+        OnUpdated?.Invoke();
+    }
+}

--- a/AvatarExplorer.Core/Services/System/Repositories/RuntimeSettingsRepository.cs
+++ b/AvatarExplorer.Core/Services/System/Repositories/RuntimeSettingsRepository.cs
@@ -4,25 +4,16 @@ using AvatarExplorer.Core.Services.IO;
 
 namespace AvatarExplorer.Core.Services.System.Repositories;
 
-public class RuntimeSettingsRepository
+public class RuntimeSettingsRepository : SettingsRepositoryBase<RuntimeSettings>
 {
-    private readonly SettingsManager<RuntimeSettings> _manager = new(SystemPath.RuntimeSettingsFilePath);
-    public RuntimeSettings Settings => _manager.Settings;
+    public RuntimeSettingsRepository() : base(SystemPath.RuntimeSettingsFilePath) { }
 
-    public event Action<RuntimeSettings>? OnSettingsChanged;
-
-    public RuntimeSettingsRepository()
-    {
-        _manager.SettingsChanged += (settings) => OnSettingsChanged?.Invoke(settings);
-    }
-
-    public void Load()
+    public override void Load(string? path = null)
     {
         DatabaseMigrationService.Migrate(
-            _manager.FilePath,
+            Manager.FilePath,
             DatabaseMigrations.RuntimeSettingsVersion,
             DatabaseMigrations.ApplyRuntimeSettingsMigration);
-        _manager.Load();
+        Manager.Load(path);
     }
-    public void Update(RuntimeSettings settings) => _manager.Update(settings);
 }

--- a/AvatarExplorer.Core/Services/System/Repositories/RuntimeSettingsRepository.cs
+++ b/AvatarExplorer.Core/Services/System/Repositories/RuntimeSettingsRepository.cs
@@ -8,12 +8,12 @@ public class RuntimeSettingsRepository : SettingsRepositoryBase<RuntimeSettings>
 {
     public RuntimeSettingsRepository() : base(SystemPath.RuntimeSettingsFilePath) { }
 
-    public override void Load(string? path = null)
+    public override void Load()
     {
         DatabaseMigrationService.Migrate(
             Manager.FilePath,
             DatabaseMigrations.RuntimeSettingsVersion,
             DatabaseMigrations.ApplyRuntimeSettingsMigration);
-        Manager.Load(path);
+        Manager.Load();
     }
 }

--- a/AvatarExplorer.Core/Services/System/Repositories/SettingsRepositoryBase.cs
+++ b/AvatarExplorer.Core/Services/System/Repositories/SettingsRepositoryBase.cs
@@ -14,7 +14,7 @@ public abstract class SettingsRepositoryBase<T> : ISettingsRepository<T> where T
         Manager.SettingsChanged += settings => OnSettingsChanged?.Invoke(settings);
     }
 
-    public abstract void Load(string? path = null);
+    public abstract void Load();
 
     public void Update(T settings)
     {

--- a/AvatarExplorer.Core/Services/System/Repositories/SettingsRepositoryBase.cs
+++ b/AvatarExplorer.Core/Services/System/Repositories/SettingsRepositoryBase.cs
@@ -1,0 +1,28 @@
+using AvatarExplorer.Core.Interfaces;
+
+namespace AvatarExplorer.Core.Services.System.Repositories;
+
+public abstract class SettingsRepositoryBase<T> : ISettingsRepository<T> where T : class, new()
+{
+    protected readonly SettingsManager<T> Manager;
+    public T Settings => Manager.Settings;
+    public event Action<T>? OnSettingsChanged;
+
+    protected SettingsRepositoryBase(string filePath)
+    {
+        Manager = new(filePath);
+        Manager.SettingsChanged += settings => OnSettingsChanged?.Invoke(settings);
+    }
+
+    public abstract void Load(string? path = null);
+
+    public void Update(T settings)
+    {
+        Manager.Update(settings);
+        Manager.Save();
+    }
+
+    public void Save() => Manager.Save();
+
+    protected void InvokeSettingsChanged(T settings) => OnSettingsChanged?.Invoke(settings);
+}

--- a/AvatarExplorer.Core/Services/System/Repositories/TempAvatarRepository.cs
+++ b/AvatarExplorer.Core/Services/System/Repositories/TempAvatarRepository.cs
@@ -1,47 +1,21 @@
 using AvatarExplorer.Core.Data.Paths;
 using AvatarExplorer.Core.Models.Items;
-using AvatarExplorer.Core.Services.Database;
 
 namespace AvatarExplorer.Core.Services.System.Repositories;
 
-public class TempAvatarRepository
+public class TempAvatarRepository : RepositoryBase<TempAvatar>
 {
-    private readonly DatabaseManager<TempAvatar> _db = new(SystemPath.TempAvatarsDatabasePath);
+    public TempAvatarRepository() : base(SystemPath.TempAvatarsDatabasePath) { }
 
-    /// <summary>
-    /// TempAvatar が追加・更新・削除された際に発火します。
-    /// </summary>
-    public event Action? OnUpdated;
-
-    public void Load()
+    public override void Load()
     {
-        _db.Load();
-        OnUpdated?.Invoke();
+        Db.Load();
+        InvokeUpdated();
     }
-    public IReadOnlyList<TempAvatar> GetAll() => _db.Items;
-
-    public TempAvatar? Get(string identifier) => _db.Items.FirstOrDefault(i => i.Identifier == identifier);
 
     public void Create(string avatarName)
     {
-        _db.Add(new(avatarName));
-        Save();
-
-        OnUpdated?.Invoke();
-    }
-
-    internal void Add(TempAvatar avatar) => _db.Add(avatar);
-
-    public void Save() => _db.Save();
-    public void Remove(string identifier)
-    {
-        var avatar = Get(identifier);
-        if (avatar == null) return;
-
-        _db.Remove(avatar.Id);
-        Save();
-
-        OnUpdated?.Invoke();
+        Add(new(avatarName));
     }
 
     public void RenameAvatar(string identifier, string newName)
@@ -51,17 +25,6 @@ public class TempAvatarRepository
 
         avatar.UpdateAvatarName(newName);
         Save();
-
-        OnUpdated?.Invoke();
+        InvokeUpdated();
     }
-
-    public void Clear()
-    {
-        _db.Clear();
-
-        Save();
-        OnUpdated?.Invoke();
-    }
-
-    public void MarkAsChanged() => OnUpdated?.Invoke();
 }

--- a/AvatarExplorer.Core/Services/System/SettingsManager.cs
+++ b/AvatarExplorer.Core/Services/System/SettingsManager.cs
@@ -12,18 +12,17 @@ public class SettingsManager<T>(string filePath) where T : class, new()
     public T Settings => _settings;
     public string FilePath => _filePath;
 
-    public void Update(T newSettings, bool save = true)
+    public void Update(T newSettings)
     {
         _settings = newSettings;
         SettingsChanged?.Invoke(newSettings);
-        if (save) Save();
     }
 
     public void Load(string? path = null)
     {
         var loadedSettings = JsonFileManager<T>.Load(path ?? _filePath);
-        if (loadedSettings != null) Update(loadedSettings, false);
-        else Update(new T(), false);
+        if (loadedSettings != null) Update(loadedSettings);
+        else Update(new T());
     }
 
     public void Save() => JsonFileManager<T>.Save(_settings, _filePath);

--- a/AvatarExplorer.Core/Services/System/SettingsManager.cs
+++ b/AvatarExplorer.Core/Services/System/SettingsManager.cs
@@ -18,9 +18,9 @@ public class SettingsManager<T>(string filePath) where T : class, new()
         SettingsChanged?.Invoke(newSettings);
     }
 
-    public void Load(string? path = null)
+    public void Load()
     {
-        var loadedSettings = JsonFileManager<T>.Load(path ?? _filePath);
+        var loadedSettings = JsonFileManager<T>.Load(_filePath);
         if (loadedSettings != null) Update(loadedSettings);
         else Update(new T());
     }

--- a/AvatarExplorer.UI/Factories/NavigationItemFactory.cs
+++ b/AvatarExplorer.UI/Factories/NavigationItemFactory.cs
@@ -1,4 +1,3 @@
-using System.Collections.ObjectModel;
 using System.Linq;
 using AvatarExplorer.Core.Localization;
 using AvatarExplorer.Core.Models.Items;
@@ -11,7 +10,7 @@ namespace AvatarExplorer.UI.Factories;
 
 public static class NavigationItemFactory
 {
-    public static ItemViewModel CreateFromNavigationable(INavigationable source)
+    public static ItemViewModel CreateFromNavigationable(IIdentifiable source)
     {
         if (source is Avatar avatar)
         {

--- a/AvatarExplorer.UI/Services/Sort/ItemSortService.cs
+++ b/AvatarExplorer.UI/Services/Sort/ItemSortService.cs
@@ -25,11 +25,11 @@ public static class ItemSortService
         return direction == SortDirection.Descending ? ordered.Reverse() : ordered;
     }
 
-    public static List<INavigationable> SortAvatars(IEnumerable<INavigationable> avatars, ItemSortOrder order, SortDirection direction, bool removeBrackets)
+    public static List<IIdentifiable> SortAvatars(IEnumerable<IIdentifiable> avatars, ItemSortOrder order, SortDirection direction, bool removeBrackets)
     {
-        var commonAvatars = new List<INavigationable>();
+        var commonAvatars = new List<IIdentifiable>();
         var items = new List<Item>();
-        var tempAvatars = new List<INavigationable>();
+        var tempAvatars = new List<IIdentifiable>();
 
         foreach (var avatar in avatars)
         {
@@ -58,7 +58,7 @@ public static class ItemSortService
         }
 
         var sortedItems = Sort(items, order, direction, removeBrackets)
-            .Select(i => (INavigationable)new Avatar(i));
+            .Select(i => (IIdentifiable)new Avatar(i));
 
         return commonAvatars.Concat(sortedItems).Concat(tempAvatars).ToList();
     }

--- a/AvatarExplorer.UI/Services/System/UserPreferencesRepository.cs
+++ b/AvatarExplorer.UI/Services/System/UserPreferencesRepository.cs
@@ -11,12 +11,12 @@ public class UserPreferencesRepository : SettingsRepositoryBase<UserPreferences>
 {
     public UserPreferencesRepository() : base(UISystemPath.UserPreferencesFilePath) { }
 
-    public override void Load(string? path = null)
+    public override void Load()
     {
         DatabaseMigrationService.Migrate(
             Manager.FilePath,
             UIMigrations.UserPreferencesVersion,
             (root, version) => UIMigrations.ApplyUserPreferencesMigration(root, version, SystemPath.RuntimeSettingsFilePath));
-        Manager.Load(path);
+        Manager.Load();
     }
 }

--- a/AvatarExplorer.UI/Services/System/UserPreferencesRepository.cs
+++ b/AvatarExplorer.UI/Services/System/UserPreferencesRepository.cs
@@ -1,32 +1,22 @@
-using System;
 using AvatarExplorer.Core.Data.Paths;
 using AvatarExplorer.Core.Services.IO;
-using AvatarExplorer.Core.Services.System;
+using AvatarExplorer.Core.Services.System.Repositories;
 using AvatarExplorer.UI.Data.Paths;
 using AvatarExplorer.UI.Models.Settings;
 using AvatarExplorer.UI.Services.IO;
 
 namespace AvatarExplorer.UI.Services.System;
 
-public class UserPreferencesRepository
+public class UserPreferencesRepository : SettingsRepositoryBase<UserPreferences>
 {
-    private readonly SettingsManager<UserPreferences> _manager = new(UISystemPath.UserPreferencesFilePath);
-    public UserPreferences Settings => _manager.Settings;
+    public UserPreferencesRepository() : base(UISystemPath.UserPreferencesFilePath) { }
 
-    public event Action<UserPreferences>? OnSettingsChanged;
-
-    public UserPreferencesRepository()
-    {
-        _manager.SettingsChanged += (settings) => OnSettingsChanged?.Invoke(settings);
-    }
-
-    public void Load(string? path = null)
+    public override void Load(string? path = null)
     {
         DatabaseMigrationService.Migrate(
-            _manager.FilePath,
+            Manager.FilePath,
             UIMigrations.UserPreferencesVersion,
             (root, version) => UIMigrations.ApplyUserPreferencesMigration(root, version, SystemPath.RuntimeSettingsFilePath));
-        _manager.Load(path);
+        Manager.Load(path);
     }
-    public void Update(UserPreferences settings) => _manager.Update(settings);
 }

--- a/AvatarExplorer.UI/ViewModels/MainViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/MainViewModel.cs
@@ -302,7 +302,7 @@ public class MainViewModel : ViewModelBase, IInitializable, IPostInitializable
         var nonItems = navigationables.Where(i => i is not Item).ToList();
 
         var sortedItems = SortNavigationItems(items, sortOrder, sortDirection, avatarId);
-        var sortedNavigationables = sortedItems.Cast<INavigationable>().Concat(nonItems);
+        var sortedNavigationables = sortedItems.Cast<IIdentifiable>().Concat(nonItems);
 
         _allMainItems = sortedNavigationables
             .Select(nav => CreateItemViewModelWithStatus(nav, avatarId, commonAvatars, implementedEnabled))
@@ -330,7 +330,7 @@ public class MainViewModel : ViewModelBase, IInitializable, IPostInitializable
         return ItemSortService.Sort(items, sortOrder, sortDirection, UserPreferences.RemoveBrackets);
     }
 
-    private ItemViewModel CreateItemViewModelWithStatus(INavigationable nav, string? avatarId, IReadOnlyList<CommonAvatar> commonAvatars, bool implementedEnabled)
+    private ItemViewModel CreateItemViewModelWithStatus(IIdentifiable nav, string? avatarId, IReadOnlyList<CommonAvatar> commonAvatars, bool implementedEnabled)
     {
         var vm = CreateItemViewModel(nav);
 
@@ -445,7 +445,7 @@ public class MainViewModel : ViewModelBase, IInitializable, IPostInitializable
     #endregion
 
     #region Items
-    private static ItemViewModel CreateItemViewModel(INavigationable item)
+    private static ItemViewModel CreateItemViewModel(IIdentifiable item)
     {
         var navigationItem = NavigationItemFactory.CreateFromNavigationable(item);
         navigationItem.Actions = ContextMenuCreator.Create(navigationItem.ViewModelType, navigationItem);


### PR DESCRIPTION
- Extract IRepository<T> and ISettingsRepository<T> interfaces
- Extract RepositoryBase<T> and SettingsRepositoryBase<T> abstract classes
- Rename INavigationable to IIdentifiable for better semantics
- Remove auto-save from DatabaseManager and SettingsManager
- Make IDatabaseItem and DatabaseManager public
- All repositories now inherit from base classes
- Remove unused path parameter from Load methods