### PR TITLE
fix(ui): clear tags when null is passed to EditTagsViewModel.Open()

### DIFF
--- a/AvatarExplorer.UI/ViewModels/Overlays/EditTagsViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/EditTagsViewModel.cs
@@ -56,7 +56,7 @@ public class EditTagsViewModel : ViewModelBase, IInitializable
     public void Open(IEnumerable<string>? tags = null)
     {
         RefleshTags();
-        if (tags != null) Tags = new ObservableCollection<string>(tags);
+        Tags = new ObservableCollection<string>(tags ?? []);
 
         NewTag = string.Empty;
     }


### PR DESCRIPTION
#513
関係あるかどうかは分からないけど普通にバグだったので