### PR TITLE
fix(ui): preserve BoothId on editor open and remove redundant save

### DIFF
--- a/AvatarExplorer.UI/ViewModels/Overlays/ItemEditorViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/ItemEditorViewModel.cs
@@ -137,7 +137,7 @@ public class ItemEditorViewModel : ViewModelBase
         Title = string.Empty;
         Author = string.Empty;
         AuthorId = string.Empty;
-        BoothId = string.Empty;
+        BoothId = launchInfo.BoothId;
         Memo = string.Empty;
         SupportedAvatars = [];
         Tags = [];

--- a/AvatarExplorer.UI/ViewModels/Overlays/ItemEditorViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/ItemEditorViewModel.cs
@@ -168,7 +168,7 @@ public class ItemEditorViewModel : ViewModelBase
         Title = string.Empty;
         Author = string.Empty;
         AuthorId = string.Empty;
-        BoothId = string.Empty;
+        BoothId = launchInfo.ItemID;
         Memo = string.Empty;
         SupportedAvatars = [];
         Tags = [];
@@ -324,7 +324,6 @@ public class ItemEditorViewModel : ViewModelBase
             );
         }
 
-        AvatarExplorerApp.Instance.Items.Save();
         Close();
     }
     private async Task SelectAndAddFolders()


### PR DESCRIPTION
LaunchInfo、BLMItemInfoでのインポート時、アイテムIDは既に貰っているのでそれをBoothIdに割り当てておくように