### PR TITLE
refactor(ui): migrate notifications to Message.Avalonia

### DIFF
--- a/AvatarExplorer.UI/App.axaml
+++ b/AvatarExplorer.UI/App.axaml
@@ -2,12 +2,14 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:ui="clr-namespace:AvatarExplorer.UI"
         xmlns:materialIcons="clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia"
+        xmlns:msg="https://github.com/xiyaowong/Message.Avalonia"
         x:Class="AvatarExplorer.UI.App"
         RequestedThemeVariant="Dark">
         <!-- "Default" ThemeVariant follows system theme variant. "Dark" or "Light" are other available options. -->
 
     <Application.Styles>
         <FluentTheme />
+        <msg:Theme />
     </Application.Styles>
 
     <Application.Resources>

--- a/AvatarExplorer.UI/AvatarExplorer.UI.csproj
+++ b/AvatarExplorer.UI/AvatarExplorer.UI.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="PDFtoImage" Version="5.2.1" />
     <PackageReference Include="ReactiveUI.Avalonia" Version="12.0.3" />
     <PackageReference Include="ReactiveUI.Fody" Version="19.5.41" />
+    <PackageReference Include="Message.Avalonia" Version="2.0.0" />
 		<ProjectReference Include="..\AvatarExplorer.Core/AvatarExplorer.Core.csproj" />
 
     <Content Include="..\AvatarExplorer.Core\Data\Localization\**\*.json">

--- a/AvatarExplorer.UI/Services/ContextMenu/ContextMenuHandlerService.cs
+++ b/AvatarExplorer.UI/Services/ContextMenu/ContextMenuHandlerService.cs
@@ -81,7 +81,7 @@ public static class ContextMenuHandlerService
         var item = Items.Get(identifier);
         if (item == null)
         {
-            MainWindowViewModel.Instance.ShowNotification(
+            MainWindowViewModel.ShowNotification(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.ItemNotFound],
                 NotificationType.Error
@@ -93,7 +93,7 @@ public static class ContextMenuHandlerService
     private static async Task EditItemInternal(string identifier, ItemEditContext context)
     {
         var result = await Items.Update(identifier, context);
-        MainWindowViewModel.Instance.ShowNotification(
+        MainWindowViewModel.ShowNotification(
             result ? Localizer.Instance[Loc.Success.Default] : Localizer.Instance[Loc.Error.Default],
             result ? Localizer.Instance[Loc.Success.ItemEdit] : Localizer.Instance[Loc.Error.ItemEditFailed],
             result ? NotificationType.Success : NotificationType.Error
@@ -105,7 +105,7 @@ public static class ContextMenuHandlerService
         var result = await LauncherService.OpenFolder(TopLevelProvider.Current, path);
         if (result.IsError)
         {
-            MainWindowViewModel.Instance.ShowNotification(
+            MainWindowViewModel.ShowNotification(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.OpenFolderFailed],
                 NotificationType.Error
@@ -120,7 +120,7 @@ public static class ContextMenuHandlerService
         var result = await ClipboardService.SetText(link);
         if (result.IsError)
         {
-            MainWindowViewModel.Instance.ShowNotification(
+            MainWindowViewModel.ShowNotification(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.ClipboardSetFailed],
                 NotificationType.Error
@@ -135,7 +135,7 @@ public static class ContextMenuHandlerService
         var result = await LauncherService.OpenUri(TopLevelProvider.Current, link);
         if (result.IsError)
         {
-            MainWindowViewModel.Instance.ShowNotification(
+            MainWindowViewModel.ShowNotification(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.OpenUriFailed],
                 NotificationType.Error
@@ -156,7 +156,7 @@ public static class ContextMenuHandlerService
         if (files == null || files.Length == 0) return;
 
         var result = await Items.UpdateThumbnail(identifier, files[0]);
-        MainWindowViewModel.Instance.ShowNotification(
+        MainWindowViewModel.ShowNotification(
             !result.IsError ? Localizer.Instance[Loc.Success.Default] : Localizer.Instance[Loc.Error.Default],
             !result.IsError ? Localizer.Instance[Loc.Success.ItemThumbnailEdit] : Localizer.Instance[Loc.Error.ItemThumbnailEditFailed],
             !result.IsError ? NotificationType.Success : NotificationType.Error
@@ -165,7 +165,7 @@ public static class ContextMenuHandlerService
     private static async void FetchThumbnail(string identifier)
     {
         var result = await Items.FetchThumbnailFromBooth(identifier);
-        MainWindowViewModel.Instance.ShowNotification(
+        MainWindowViewModel.ShowNotification(
             !result.IsError ? Localizer.Instance[Loc.Success.Default] : Localizer.Instance[Loc.Error.Default],
             !result.IsError ? Localizer.Instance[Loc.Success.FetchItemThumbnail] : Localizer.Instance[Loc.Error.FetchItemThumbnailFailed],
             !result.IsError ? NotificationType.Success : NotificationType.Error
@@ -180,7 +180,7 @@ public static class ContextMenuHandlerService
         var result = await ClipboardService.SetText(itemInfo);
         if (result.IsError)
         {
-            MainWindowViewModel.Instance.ShowNotification(
+            MainWindowViewModel.ShowNotification(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.ClipboardSetFailed],
                 NotificationType.Error
@@ -254,7 +254,7 @@ public static class ContextMenuHandlerService
 
         if (extractResult.IsError)
         {
-            MainWindowViewModel.Instance.ShowNotification(
+            MainWindowViewModel.ShowNotification(
                 Localizer.Instance[Loc.Error.Default],
                 isFile ? Localizer.Instance[Loc.Error.AddItemFileFailed] : Localizer.Instance[Loc.Error.AddItemFolderFailed],
                 NotificationType.Error
@@ -262,7 +262,7 @@ public static class ContextMenuHandlerService
         }
         else if (extractResult.Value.ProcessingFailedPaths.Count > 0)
         {
-            MainWindowViewModel.Instance.ShowNotification(
+            MainWindowViewModel.ShowNotification(
                 Localizer.Instance[Loc.Warning.Default],
                 Localizer.Instance.Get(
                     Loc.Error.FoundProcessingFailedPath,
@@ -273,7 +273,7 @@ public static class ContextMenuHandlerService
         }
         else
         {
-            MainWindowViewModel.Instance.ShowNotification(
+            MainWindowViewModel.ShowNotification(
                 Localizer.Instance[Loc.Success.Default],
                 isFile ? Localizer.Instance[Loc.Success.ItemFileAdd] : Localizer.Instance[Loc.Success.ItemFolderAdd],
                 NotificationType.Success
@@ -309,7 +309,7 @@ public static class ContextMenuHandlerService
         if (folders == null || folders.Length == 0) return;
 
         var result = await Items.Update(item.Identifier, new() { ItemPath = folders[0] });
-        MainWindowViewModel.Instance.ShowNotification(
+        MainWindowViewModel.ShowNotification(
             result ? Localizer.Instance[Loc.Success.Default] : Localizer.Instance[Loc.Error.Default],
             result ? Localizer.Instance[Loc.Success.ItemEdit] : Localizer.Instance[Loc.Error.ItemEditFailed],
             result ? NotificationType.Success : NotificationType.Error
@@ -348,7 +348,7 @@ public static class ContextMenuHandlerService
 
         ItemGroupService.RemoveItem(item.Identifier, removeDirectory);
 
-        MainWindowViewModel.Instance.ShowNotification(
+        MainWindowViewModel.ShowNotification(
             Localizer.Instance[Loc.Success.Default],
             Localizer.Instance[Loc.Success.Remove],
             NotificationType.Success
@@ -359,7 +359,7 @@ public static class ContextMenuHandlerService
         var result = await LauncherService.OpenFile(TopLevelProvider.Current, path);
         if (result.IsError)
         {
-            MainWindowViewModel.Instance.ShowNotification(
+            MainWindowViewModel.ShowNotification(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.OpenFileFailed],
                 NotificationType.Error
@@ -384,7 +384,7 @@ public static class ContextMenuHandlerService
         }
         catch (Exception ex)
         {
-            MainWindowViewModel.Instance.ShowNotification(
+            MainWindowViewModel.ShowNotification(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.OpenFileFailed],
                 NotificationType.Error
@@ -405,7 +405,7 @@ public static class ContextMenuHandlerService
         var preset = AvatarExplorerApp.Instance.BulkImportPresets.Get(identifier);
         if (preset == null)
         {
-            MainWindowViewModel.Instance.ShowNotification(
+            MainWindowViewModel.ShowNotification(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.PresetNotFound],
                 NotificationType.Error
@@ -421,7 +421,7 @@ public static class ContextMenuHandlerService
 
         AvatarExplorerApp.Instance.BulkImportPresets.Remove(preset.Identifier);
 
-        MainWindowViewModel.Instance.ShowNotification(
+        MainWindowViewModel.ShowNotification(
             Localizer.Instance[Loc.Success.Default],
             Localizer.Instance[Loc.Success.Remove],
             NotificationType.Success
@@ -432,7 +432,7 @@ public static class ContextMenuHandlerService
         var tempAvatar = AvatarExplorerApp.Instance.TempAvatars.Get(identifier);
         if (tempAvatar == null)
         {
-            MainWindowViewModel.Instance.ShowNotification(
+            MainWindowViewModel.ShowNotification(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.TempAvatarNotFound],
                 NotificationType.Error
@@ -448,7 +448,7 @@ public static class ContextMenuHandlerService
 
         AvatarExplorerApp.Instance.TempAvatars.RenameAvatar(tempAvatar.Identifier, newName);
 
-        MainWindowViewModel.Instance.ShowNotification(
+        MainWindowViewModel.ShowNotification(
             Localizer.Instance[Loc.Success.Default],
             Localizer.Instance[Loc.Success.ItemEdit],
             NotificationType.Success
@@ -463,7 +463,7 @@ public static class ContextMenuHandlerService
         var tempAvatar = AvatarExplorerApp.Instance.TempAvatars.Get(identifier);
         if (tempAvatar == null)
         {
-            MainWindowViewModel.Instance.ShowNotification(
+            MainWindowViewModel.ShowNotification(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.TempAvatarNotFound],
                 NotificationType.Error
@@ -479,7 +479,7 @@ public static class ContextMenuHandlerService
 
         ItemGroupService.RemoveTempAvatar(tempAvatar.Identifier);
 
-        MainWindowViewModel.Instance.ShowNotification(
+        MainWindowViewModel.ShowNotification(
             Localizer.Instance[Loc.Success.Default],
             Localizer.Instance[Loc.Success.Remove],
             NotificationType.Success
@@ -510,7 +510,7 @@ public static class ContextMenuHandlerService
 
         AvatarExplorerApp.Instance.Items.RenameCustomCategory(oldCategory, newName);
 
-        MainWindowViewModel.Instance.ShowNotification(
+        MainWindowViewModel.ShowNotification(
             Localizer.Instance[Loc.Success.Default],
             Localizer.Instance[Loc.Success.RenameCustomCategory],
             NotificationType.Success

--- a/AvatarExplorer.UI/ViewModels/MainViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/MainViewModel.cs
@@ -201,7 +201,7 @@ public class MainViewModel : ViewModelBase, IInitializable, IPostInitializable
             var itemId = _itemNavigationService.GetCurrentItemId();
             if (itemId == null)
             {
-                MainWindowViewModel.Instance.ShowNotification(
+                MainWindowViewModel.ShowNotification(
                     Localizer.Instance[Loc.Error.Default],
                     Localizer.Instance[Loc.Error.FailedToGetCurrentItem],
                     NotificationType.Error
@@ -212,7 +212,7 @@ public class MainViewModel : ViewModelBase, IInitializable, IPostInitializable
             var item = _itemGroupService.ItemRepository.Get(itemId);
             if (item == null)
             {
-                MainWindowViewModel.Instance.ShowNotification(
+                MainWindowViewModel.ShowNotification(
                     Localizer.Instance[Loc.Error.Default],
                     Localizer.Instance[Loc.Error.ItemNotFound],
                     NotificationType.Error
@@ -242,7 +242,7 @@ public class MainViewModel : ViewModelBase, IInitializable, IPostInitializable
                 var result = await LauncherService.OpenFile(TopLevelProvider.Current, importResult.ModifiedUnitypackagePath);
                 if (result.IsError)
                 {
-                    MainWindowViewModel.Instance.ShowNotification(
+                    MainWindowViewModel.ShowNotification(
                         Localizer.Instance[Loc.Error.Default],
                         Localizer.Instance[Loc.Error.OpenFileFailed],
                         NotificationType.Error
@@ -251,7 +251,7 @@ public class MainViewModel : ViewModelBase, IInitializable, IPostInitializable
             }
             else
             {
-                MainWindowViewModel.Instance.ShowNotification(
+                MainWindowViewModel.ShowNotification(
                     Localizer.Instance[Loc.Error.Default],
                     Localizer.Instance[Loc.Error.ImportUnitypackageFailed],
                     NotificationType.Error
@@ -263,7 +263,7 @@ public class MainViewModel : ViewModelBase, IInitializable, IPostInitializable
             var result = await LauncherService.OpenFile(TopLevelProvider.Current, file);
             if (result.IsError)
             {
-                MainWindowViewModel.Instance.ShowNotification(
+                MainWindowViewModel.ShowNotification(
                     Localizer.Instance[Loc.Error.Default],
                     Localizer.Instance[Loc.Error.OpenFileFailed],
                     NotificationType.Error

--- a/AvatarExplorer.UI/ViewModels/MainWindowViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/MainWindowViewModel.cs
@@ -22,6 +22,8 @@ using AvatarExplorer.UI.Services.System;
 using AvatarExplorer.UI.Services.Utilities;
 using AvatarExplorer.UI.Utils;
 using AvatarExplorer.UI.ViewModels.Overlays;
+using Message.Avalonia;
+using Message.Avalonia.Models;
 using ReactiveUI.Fody.Helpers;
 
 namespace AvatarExplorer.UI.ViewModels;
@@ -336,15 +338,48 @@ public class MainWindowViewModel : ViewModelBase, IInitializable, IPostInitializ
         application.RequestedThemeVariant = theme;
     }
 
-    public void ShowNotification(string title, string content, NotificationType type)
+    public static void ShowNotification(string title, string content, NotificationType type)
     {
-        NotificationManager?.Show(new Notification()
+        var manager = MessageManager.Default;
+        switch (type)
         {
-            Title = title,
-            Message = content,
-            Type = type,
-            Expiration = TimeSpan.FromSeconds(5)
-        });
+            case NotificationType.Information:
+                manager.ShowInformationMessage(
+                    content,
+                    new MessageOptions{
+                        Title = title,
+                        Duration = TimeSpan.FromSeconds(3.5)
+                    }
+                );
+                break;
+            case NotificationType.Success:
+                manager.ShowSuccessMessage(
+                    content,
+                    new MessageOptions{
+                        Title = title,
+                        Duration = TimeSpan.FromSeconds(3.5)
+                    }
+                );
+                break;
+            case NotificationType.Warning:
+                manager.ShowWarningMessage(
+                    content,
+                    new MessageOptions{
+                        Title = title,
+                        Duration = TimeSpan.FromSeconds(3.5)
+                    }
+                );
+                break;
+            case NotificationType.Error:
+                manager.ShowErrorMessage(
+                    content,
+                    new MessageOptions{
+                        Title = title,
+                        Duration = TimeSpan.FromSeconds(3.5)
+                    }
+                );
+                break;
+        }
     }
 
     public void OnWindowClosing()

--- a/AvatarExplorer.UI/ViewModels/MainWindowViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/MainWindowViewModel.cs
@@ -341,43 +341,25 @@ public class MainWindowViewModel : ViewModelBase, IInitializable, IPostInitializ
     public static void ShowNotification(string title, string content, NotificationType type)
     {
         var manager = MessageManager.Default;
+        var messageOptions = new MessageOptions
+        {
+            Title = title,
+            Duration = TimeSpan.FromSeconds(3.5)
+        };
+
         switch (type)
         {
             case NotificationType.Information:
-                manager.ShowInformationMessage(
-                    content,
-                    new MessageOptions{
-                        Title = title,
-                        Duration = TimeSpan.FromSeconds(3.5)
-                    }
-                );
+                manager.ShowInformationMessage(content, messageOptions);
                 break;
             case NotificationType.Success:
-                manager.ShowSuccessMessage(
-                    content,
-                    new MessageOptions{
-                        Title = title,
-                        Duration = TimeSpan.FromSeconds(3.5)
-                    }
-                );
+                manager.ShowSuccessMessage(content, messageOptions);
                 break;
             case NotificationType.Warning:
-                manager.ShowWarningMessage(
-                    content,
-                    new MessageOptions{
-                        Title = title,
-                        Duration = TimeSpan.FromSeconds(3.5)
-                    }
-                );
+                manager.ShowWarningMessage(content, messageOptions);
                 break;
             case NotificationType.Error:
-                manager.ShowErrorMessage(
-                    content,
-                    new MessageOptions{
-                        Title = title,
-                        Duration = TimeSpan.FromSeconds(3.5)
-                    }
-                );
+                manager.ShowErrorMessage(content, messageOptions);
                 break;
         }
     }

--- a/AvatarExplorer.UI/ViewModels/Overlays/EditCommonAvatarsViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/EditCommonAvatarsViewModel.cs
@@ -102,7 +102,7 @@ public class EditCommonAvatarsViewModel : ViewModelBase, IInitializable
         var group = SelectedGroup;
         if (group == null)
         {
-            MainWindowViewModel.Instance.ShowNotification(
+            MainWindowViewModel.ShowNotification(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.CommonAvatarNotFound],
                 NotificationType.Error
@@ -122,7 +122,7 @@ public class EditCommonAvatarsViewModel : ViewModelBase, IInitializable
         var group = SelectedGroup;
         if (group == null)
         {
-            MainWindowViewModel.Instance.ShowNotification(
+            MainWindowViewModel.ShowNotification(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.CommonAvatarNotFound],
                 NotificationType.Error

--- a/AvatarExplorer.UI/ViewModels/Overlays/ExportDataViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/ExportDataViewModel.cs
@@ -64,7 +64,7 @@ public class ExportDataViewModel : ViewModelBase
 
         if (result.IsError)
         {
-            MainWindowViewModel.Instance.ShowNotification(
+            MainWindowViewModel.ShowNotification(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.ExportFailed],
                 NotificationType.Error
@@ -72,7 +72,7 @@ public class ExportDataViewModel : ViewModelBase
         }
         else
         {
-            MainWindowViewModel.Instance.ShowNotification(
+            MainWindowViewModel.ShowNotification(
                 Localizer.Instance[Loc.Success.Default],
                 Localizer.Instance[Loc.Success.Export],
                 NotificationType.Success

--- a/AvatarExplorer.UI/ViewModels/Overlays/FetchAllThumbnailsViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/FetchAllThumbnailsViewModel.cs
@@ -75,7 +75,7 @@ public class FetchAllThumbnailsViewModel : ViewModelBase
         var allItems = AvatarExplorerApp.Instance.Items.GetAll();
         if (allItems.Count == 0)
         {
-            MainWindowViewModel.Instance.ShowNotification(
+            MainWindowViewModel.ShowNotification(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.Nothing],
                 NotificationType.Error
@@ -164,7 +164,7 @@ public class FetchAllThumbnailsViewModel : ViewModelBase
         if (isCancelled)
         {
             Status = Localizer.Instance[Loc.FetchAllThumbnails.Status.Cancelled];
-            MainWindowViewModel.Instance.ShowNotification(
+            MainWindowViewModel.ShowNotification(
                 Localizer.Instance[Loc.Warning.Default],
                 Localizer.Instance.Get(Loc.Warning.FetchAllItemThumbnailsCancelled, [successCount.ToString(), failureCount.ToString(), allItems.Count.ToString()]),
                 NotificationType.Warning
@@ -176,7 +176,7 @@ public class FetchAllThumbnailsViewModel : ViewModelBase
 
         if (failureCount == 0)
         {
-            MainWindowViewModel.Instance.ShowNotification(
+            MainWindowViewModel.ShowNotification(
                 Localizer.Instance[Loc.Success.Default],
                 Localizer.Instance.Get(Loc.Success.FetchAllItemThumbnails, successCount.ToString()),
                 NotificationType.Success
@@ -184,7 +184,7 @@ public class FetchAllThumbnailsViewModel : ViewModelBase
         }
         else
         {
-            MainWindowViewModel.Instance.ShowNotification(
+            MainWindowViewModel.ShowNotification(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance.Get(Loc.Error.FetchAllItemThumbnailsFailed, [successCount.ToString(), failureCount.ToString(), allItems.Count.ToString()]),
                 NotificationType.Error

--- a/AvatarExplorer.UI/ViewModels/Overlays/ImportDataViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/ImportDataViewModel.cs
@@ -100,7 +100,7 @@ public class ImportDataViewModel : ViewModelBase
 
         if (result.IsError)
         {
-            MainWindowViewModel.Instance.ShowNotification(
+            MainWindowViewModel.ShowNotification(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.ImportFailed],
                 NotificationType.Error
@@ -108,7 +108,7 @@ public class ImportDataViewModel : ViewModelBase
             return;
         }
 
-        MainWindowViewModel.Instance.ShowNotification(
+        MainWindowViewModel.ShowNotification(
             Localizer.Instance[Loc.Success.Default],
             Localizer.Instance[Loc.Success.Import],
             NotificationType.Success

--- a/AvatarExplorer.UI/ViewModels/Overlays/InitialSetupViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/InitialSetupViewModel.cs
@@ -99,7 +99,7 @@ public class InitialSetupViewModel : ViewModelBase, IInitializable, IPostInitial
             }
 
             SchemeService.RegisterScheme(SchemeService.ProtocolVRCAE);
-            MainWindowViewModel.Instance.ShowNotification(
+            MainWindowViewModel.ShowNotification(
                 Localizer.Instance[Loc.Success.Default],
                 Localizer.Instance[Loc.Scheme.RegisterSuccess],
                 NotificationType.Success
@@ -107,7 +107,7 @@ public class InitialSetupViewModel : ViewModelBase, IInitializable, IPostInitial
         }
         else
         {
-            MainWindowViewModel.Instance.ShowNotification(
+            MainWindowViewModel.ShowNotification(
                 Localizer.Instance[Loc.Dialog.Confirmation.Default],
                 Localizer.Instance[Loc.Scheme.RegisterSkipped],
                 NotificationType.Information

--- a/AvatarExplorer.UI/ViewModels/Overlays/ItemEditorViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/ItemEditorViewModel.cs
@@ -249,7 +249,7 @@ public class ItemEditorViewModel : ViewModelBase
         };
 
         bool updateResult = await AvatarExplorerApp.Instance.Items.Update(identifier, editContext);
-        MainWindowViewModel.Instance.ShowNotification(
+        MainWindowViewModel.ShowNotification(
             Localizer.Instance[updateResult ? Loc.Success.Default : Loc.Error.Default],
             Localizer.Instance[updateResult ? Loc.Success.ItemEdit : Loc.Error.ItemEditFailed],
             updateResult ? NotificationType.Success : NotificationType.Error
@@ -287,7 +287,7 @@ public class ItemEditorViewModel : ViewModelBase
         }
 
         var item = await AvatarExplorerApp.Instance.Items.Create(creationContext);
-        MainWindowViewModel.Instance.ShowNotification(
+        MainWindowViewModel.ShowNotification(
             Localizer.Instance[Loc.Success.Default],
             Localizer.Instance[Loc.Success.ItemAdd],
             NotificationType.Success
@@ -297,7 +297,7 @@ public class ItemEditorViewModel : ViewModelBase
 
     private async Task AddPathsInBackground(string identifier, List<ItemPathEntry> itemPaths, bool shouldLinkToOriginal)
     {
-        MainWindowViewModel.Instance.ShowNotification(
+        MainWindowViewModel.ShowNotification(
             Localizer.Instance[Loc.Processing.Default],
             Localizer.Instance[Loc.Processing.AddContent],
             NotificationType.Information
@@ -309,7 +309,7 @@ public class ItemEditorViewModel : ViewModelBase
 
             if (result.IsError)
             {
-                MainWindowViewModel.Instance.ShowNotification(
+                MainWindowViewModel.ShowNotification(
                     Localizer.Instance[Loc.Error.Default],
                     Localizer.Instance[Loc.Error.AddContentFailed],
                     NotificationType.Error
@@ -317,7 +317,7 @@ public class ItemEditorViewModel : ViewModelBase
             }
             else if (result.Value.ProcessingFailedPaths.Count > 0)
             {
-                MainWindowViewModel.Instance.ShowNotification(
+                MainWindowViewModel.ShowNotification(
                     Localizer.Instance[Loc.Error.Default],
                     Localizer.Instance.Get(Loc.Error.FoundProcessingFailedPath, result.Value.ProcessingFailedPaths.Count.ToString()),
                     NotificationType.Error
@@ -325,7 +325,7 @@ public class ItemEditorViewModel : ViewModelBase
             }
             else
             {
-                MainWindowViewModel.Instance.ShowNotification(
+                MainWindowViewModel.ShowNotification(
                     Localizer.Instance[Loc.Success.Default],
                     Localizer.Instance[Loc.Success.ContentAdd],
                     NotificationType.Success
@@ -366,7 +366,7 @@ public class ItemEditorViewModel : ViewModelBase
 
         if (!UriUtils.TryParse(url, out var uri))
         {
-            MainWindowViewModel.Instance.ShowNotification(
+            MainWindowViewModel.ShowNotification(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.InvalidUrl],
                 NotificationType.Error
@@ -386,7 +386,7 @@ public class ItemEditorViewModel : ViewModelBase
 
         if (fetchResult.IsError)
         {
-            MainWindowViewModel.Instance.ShowNotification(
+            MainWindowViewModel.ShowNotification(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.RetrieveBoothItemFailed],
                 NotificationType.Error
@@ -490,7 +490,7 @@ public class ItemEditorViewModel : ViewModelBase
         // Title
         if (string.IsNullOrWhiteSpace(Title))
         {
-            MainWindowViewModel.Instance.ShowNotification(
+            MainWindowViewModel.ShowNotification(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.Validation.EmptyTitle],
                 NotificationType.Error
@@ -501,7 +501,7 @@ public class ItemEditorViewModel : ViewModelBase
         // Author
         if (string.IsNullOrWhiteSpace(Author))
         {
-            MainWindowViewModel.Instance.ShowNotification(
+            MainWindowViewModel.ShowNotification(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.Validation.EmptyAuthor],
                 NotificationType.Error
@@ -512,7 +512,7 @@ public class ItemEditorViewModel : ViewModelBase
         // Category
         if (SelectedCategory == null)
         {
-            MainWindowViewModel.Instance.ShowNotification(
+            MainWindowViewModel.ShowNotification(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.InvalidCategory],
                 NotificationType.Error
@@ -523,7 +523,7 @@ public class ItemEditorViewModel : ViewModelBase
         // Supported Avatars
         if (SelectedCategory.Category.Type != ItemType.Clothing && SupportedAvatars.Any(i => i.StartsWith("commonavatar")))
         {
-            MainWindowViewModel.Instance.ShowNotification(
+            MainWindowViewModel.ShowNotification(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.Validation.NotClothingWithCommonAvatar],
                 NotificationType.Error

--- a/AvatarExplorer.UI/ViewModels/Overlays/ResolveTempAvatarViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/ResolveTempAvatarViewModel.cs
@@ -86,7 +86,7 @@ public class ResolveTempAvatarViewModel : ViewModelBase, IInitializable
     {
         if (SelectedAvatar == null)
         {
-            MainWindowViewModel.Instance.ShowNotification(
+            MainWindowViewModel.ShowNotification(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.TempAvatarNotFound],
                 NotificationType.Error
@@ -97,7 +97,7 @@ public class ResolveTempAvatarViewModel : ViewModelBase, IInitializable
         var tempAvatar = AvatarExplorerApp.Instance.TempAvatars.Get(SelectedAvatar);
         if (tempAvatar == null)
         {
-            MainWindowViewModel.Instance.ShowNotification(
+            MainWindowViewModel.ShowNotification(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.TempAvatarNotFound],
                 NotificationType.Error

--- a/AvatarExplorer.UI/ViewModels/Overlays/SettingsViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/SettingsViewModel.cs
@@ -367,7 +367,7 @@ public class SettingsViewModel : ViewModelBase, IInitializable
     {
         if (!ProcessUtils.IsWindows())
         {
-            MainWindowViewModel.Instance.ShowNotification(
+            MainWindowViewModel.ShowNotification(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.NonWindowsUnsupported],
                 NotificationType.Error
@@ -399,7 +399,7 @@ public class SettingsViewModel : ViewModelBase, IInitializable
         SchemeService.RegisterScheme(protocol);
         UpdateSchemeStatus();
 
-        MainWindowViewModel.Instance.ShowNotification(
+        MainWindowViewModel.ShowNotification(
             Localizer.Instance[Loc.Success.Default],
             Localizer.Instance[Loc.Scheme.RegisterSuccess],
             NotificationType.Success
@@ -430,7 +430,7 @@ public class SettingsViewModel : ViewModelBase, IInitializable
         SchemeService.UnregisterScheme(protocol);
         UpdateSchemeStatus();
 
-        MainWindowViewModel.Instance.ShowNotification(
+        MainWindowViewModel.ShowNotification(
             Localizer.Instance[Loc.Success.Default],
             Localizer.Instance[Loc.Settings.RegisterScheme.UnregisterSuccess],
             NotificationType.Success
@@ -443,7 +443,7 @@ public class SettingsViewModel : ViewModelBase, IInitializable
         var result = await UpdateChecker.CheckForUpdate((UpdateChannel)SelectedUpdateChannel);
         if (!result)
         {
-            MainWindowViewModel.Instance.ShowNotification(
+            MainWindowViewModel.ShowNotification(
                 Localizer.Instance[Loc.UpdateDialog.NoUpdateAvailableTitle],
                 Localizer.Instance.Get(Loc.UpdateDialog.NoUpdateAvailable, AvatarExplorerApp.CurrentVersion),
                 NotificationType.Information
@@ -472,7 +472,7 @@ public class SettingsViewModel : ViewModelBase, IInitializable
         if (File.Exists(licensePath)) await LauncherService.OpenUri(TopLevelProvider.Current, licensePath);
         else
         {
-            MainWindowViewModel.Instance.ShowNotification(
+            MainWindowViewModel.ShowNotification(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.LicenseFileNotFound],
                 NotificationType.Error
@@ -486,7 +486,7 @@ public class SettingsViewModel : ViewModelBase, IInitializable
         if (File.Exists(licensePath)) await LauncherService.OpenUri(TopLevelProvider.Current, licensePath);
         else
         {
-            MainWindowViewModel.Instance.ShowNotification(
+            MainWindowViewModel.ShowNotification(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.ThirdPartyLicenseFileNotFound],
                 NotificationType.Error

--- a/AvatarExplorer.UI/ViewModels/Overlays/UnitypackageViewerViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/UnitypackageViewerViewModel.cs
@@ -154,7 +154,7 @@ public class UnitypackageViewerViewModel : ViewModelBase, IInitializable
         if (result.IsError)
         {
             ErrorManager.Instance.PostInternalError("Failed to export unitypackage asset.", tag: result.Errors.ToErrorString());
-            MainWindowViewModel.Instance.ShowNotification(
+            MainWindowViewModel.ShowNotification(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.ExportFailed],
                 NotificationType.Error

--- a/AvatarExplorer.UI/ViewModels/Panels/BulkImportViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Panels/BulkImportViewModel.cs
@@ -97,7 +97,7 @@ public class BulkImportViewModel : ViewModelBase, IInitializable
             var result = await LauncherService.OpenFile(TopLevelProvider.Current, importResult.ModifiedUnitypackagePath);
             if (result.IsError)
             {
-                MainWindowViewModel.Instance.ShowNotification(
+                MainWindowViewModel.ShowNotification(
                     Localizer.Instance[Loc.Error.Default],
                     Localizer.Instance[Loc.Error.OpenFileFailed],
                     NotificationType.Error
@@ -106,7 +106,7 @@ public class BulkImportViewModel : ViewModelBase, IInitializable
         }
         else
         {
-            MainWindowViewModel.Instance.ShowNotification(
+            MainWindowViewModel.ShowNotification(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.BulkImportFailed],
                 NotificationType.Error
@@ -156,7 +156,7 @@ public class BulkImportViewModel : ViewModelBase, IInitializable
 
         if (unitypackagePaths.Length == 0)
         {
-            MainWindowViewModel.Instance.ShowNotification(
+            MainWindowViewModel.ShowNotification(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.UnitypackageNotFound],
                 NotificationType.Warning

--- a/AvatarExplorer.UI/Views/MainWindow.axaml
+++ b/AvatarExplorer.UI/Views/MainWindow.axaml
@@ -5,6 +5,7 @@
         xmlns:overlays="using:AvatarExplorer.UI.Views.Overlays"
         xmlns:views="using:AvatarExplorer.UI.Views"
         xmlns:vm="using:AvatarExplorer.UI.ViewModels"
+        xmlns:msg="https://github.com/xiyaowong/Message.Avalonia"
         Icon="avares://AvatarExplorer/Assets/Internal/SoftwareIcon.png"
         WindowStartupLocation="CenterScreen"
         FontFamily="{Binding FontFamily}"
@@ -109,6 +110,6 @@
             <overlays:FatalErrorOverlay/>
         </ContentControl>
 
-        <WindowNotificationManager x:Name="NotificationManager" Position="BottomRight"/>
+        <msg:MessageHost Position="BottomRight"/>
     </Panel>
 </Window>

--- a/AvatarExplorer.UI/Views/MainWindow.axaml.cs
+++ b/AvatarExplorer.UI/Views/MainWindow.axaml.cs
@@ -14,7 +14,6 @@ public partial class MainWindow : Window
     public MainWindow()
     {
         InitializeComponent();
-        MainWindowViewModel.Instance.NotificationManager = NotificationManager;
         SingleInstanceService.OnPipeMessageReceived += OnPipeMessageReceived;
     }
 

--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -227,6 +227,30 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
+- Message.Avalonia (https://github.com/xiyaowong/Message.Avalonia)
+
+MIT License
+
+Copyright (c) 2025 wongxy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
 - Material.Icons (https://github.com/SKProCH/Material.Icons)
 
 MIT License


### PR DESCRIPTION
Replace the built-in WindowNotificationManager with the Message.Avalonia library for toast notifications.

- Add Message.Avalonia package and Theme resource
- Replace WindowNotificationManager with MessageHost in MainWindow
- Make ShowNotification static and route NotificationType to the corresponding MessageManager methods
- Update all call sites and add third-party license entry