### PR TITLE
fix(ui): support temp avatar and common avatar resolution in AvatarPrefix path formatting

### DIFF
--- a/AvatarExplorer.UI/ViewModels/MainViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/MainViewModel.cs
@@ -431,7 +431,21 @@ public class MainViewModel : ViewModelBase, IInitializable, IPostInitializable
                 return value;
 
             if (prefix == ItemNavigationService.AvatarPrefix)
-                return AvatarExplorerApp.Instance.Items.Get(value)?.Title ?? value;
+            {
+                // Item
+                if (value.StartsWith("item"))
+                    return AvatarExplorerApp.Instance.Items.Get(value)?.Title ?? value;
+
+                // Temp Avatar
+                if (value.StartsWith("tempavatar"))
+                    return AvatarExplorerApp.Instance.TempAvatars.Get(value)?.AvatarName ?? value;
+
+                // Common Avatar (現在は未実装)
+                if (value.StartsWith("commonavatar"))
+                    return AvatarExplorerApp.Instance.CommonAvatars.Get(value)?.GroupName ?? value;
+
+                return value;
+            }
 
             if (prefix == ItemNavigationService.ItemPrefix)
                 return AvatarExplorerApp.Instance.Items.Get(state)?.Title ?? value;


### PR DESCRIPTION
AvatarPrefix previously only resolved Items regardless of the actual value type. Now it dispatches to the correct data source based on the value prefix (item, tempavatar, commonavatar).

Fixes #600 