### PR TITLE
fix(ui): mask username and extract application name from scheme registration path

### DIFF
--- a/AvatarExplorer.UI/ViewModels/Overlays/SettingsViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/SettingsViewModel.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -366,7 +367,14 @@ public class SettingsViewModel : ViewModelBase, IInitializable
         if (SchemeService.IsAnySchemeRegistered(protocol))
         {
             var command = SchemeService.GetRegisteredCommand(protocol) ?? "";
-            return Localizer.Instance.Get(Loc.Settings.RegisterScheme.Status.Other, command);
+            var applicationName = command.Split(" ").FirstOrDefault() ?? "";
+            
+            // ユーザー名を*****にする
+            var userName = Environment.UserName;
+            var maskedUserName = new string('*', userName.Length);
+            applicationName = applicationName.Replace(userName, maskedUserName);
+
+            return Localizer.Instance.Get(Loc.Settings.RegisterScheme.Status.Other, applicationName);
         }
 
         return Localizer.Instance[Loc.Settings.RegisterScheme.Status.None];


### PR DESCRIPTION
Previously displayed the full command including %1 argument and username which was confusing and exposed user information. Now properly extracts just the application name and masks the username with asterisks.