### PR TITLE
fix(backup): remove redundant restore confirmation dialog

### DIFF
--- a/AvatarExplorer.Core/Data/Localization/en-US.json
+++ b/AvatarExplorer.Core/Data/Localization/en-US.json
@@ -51,7 +51,6 @@
     "Dialog.Confirmation.ResetDatabase": "Are you sure you want to reset the selected databases?\n※ Asset data will not be deleted. It can be restored from automatic backup.",
     "Dialog.Confirmation.RemoveCommonAvatarGroup": "Delete the common avatar group?\nCommon Avatar Group Name: {0}",
     "Dialog.Confirmation.RemoveTempAvatar": "Temporary Avatar Name: {0}\n\nAre you sure you want to delete this avatar?",
-    "Dialog.Confirmation.ContinueRestoreFromBackup": "Failed to backup current settings, but continue restoring from backup?",
     "Dialog.Confirmation.RemovePreset": "Preset Name: {0}\n\nAre you sure you want to delete this preset?",
     "Dialog.Confirmation.AddToExistingItem": "An item with the same Booth ID has already been added. Do you want to add files or folders to that item?",
     "Dialog.Confirmation.ResolveTempAvatar": "Confirm linking temporary avatar \"{0}\" to permanent item \"{1}\"?",

--- a/AvatarExplorer.Core/Data/Localization/es-ES.json
+++ b/AvatarExplorer.Core/Data/Localization/es-ES.json
@@ -51,7 +51,6 @@
     "Dialog.Confirmation.ResetDatabase": "¿Seguro que quieres reiniciar las bases de datos seleccionadas?\n※ Los datos de los recursos no se eliminarán. Se pueden restaurar desde la copia de seguridad automática.",
     "Dialog.Confirmation.RemoveCommonAvatarGroup": "¿Eliminar el grupo de avatares comunes?\nNombre del grupo de avatares comunes: {0}",
     "Dialog.Confirmation.RemoveTempAvatar": "Nombre del avatar temporal: {0}\n\n¿Seguro que quieres eliminar este avatar?",
-    "Dialog.Confirmation.ContinueRestoreFromBackup": "Falló la copia de seguridad de la configuración actual, ¿quieres continuar restaurando desde la copia de seguridad?",
     "Dialog.Confirmation.RemovePreset": "Nombre del ajuste preestablecido: {0}\n\n¿Seguro que quieres eliminar este ajuste?",
     "Dialog.Confirmation.AddToExistingItem": "Ya se agregó un elemento con el mismo Booth ID. ¿Quieres agregar archivos o carpetas a ese elemento?",
     "Dialog.Confirmation.ResolveTempAvatar": "¿Confirmar la vinculación del avatar temporal \"{0}\" con el elemento permanente \"{1}\"?",

--- a/AvatarExplorer.Core/Data/Localization/fr-FR.json
+++ b/AvatarExplorer.Core/Data/Localization/fr-FR.json
@@ -51,7 +51,6 @@
     "Dialog.Confirmation.ResetDatabase": "Voulez-vous vraiment réinitialiser les bases de données sélectionnées ?\n※ Les données des ressources ne seront pas supprimées. Elles peuvent être restaurées à partir de la sauvegarde automatique.",
     "Dialog.Confirmation.RemoveCommonAvatarGroup": "Supprimer le groupe d'avatars communs ?\nNom du groupe d'avatars communs : {0}",
     "Dialog.Confirmation.RemoveTempAvatar": "Nom de l'avatar temporaire : {0}\n\nVoulez-vous vraiment supprimer cet avatar ?",
-    "Dialog.Confirmation.ContinueRestoreFromBackup": "La sauvegarde des paramètres actuels a échoué, mais voulez-vous quand même continuer la restauration à partir de la sauvegarde ?",
     "Dialog.Confirmation.RemovePreset": "Nom du préréglage : {0}\n\nVoulez-vous vraiment supprimer ce préréglage ?",
     "Dialog.Confirmation.AddToExistingItem": "Un élément avec le même Booth ID a déjà été ajouté. Voulez-vous ajouter des fichiers ou des dossiers à cet élément ?",
     "Dialog.Confirmation.ResolveTempAvatar": "Confirmer la liaison de l'avatar temporaire \"{0}\" à l'élément permanent \"{1}\" ?",

--- a/AvatarExplorer.Core/Data/Localization/ja-JP.json
+++ b/AvatarExplorer.Core/Data/Localization/ja-JP.json
@@ -51,7 +51,6 @@
     "Dialog.Confirmation.ResetDatabase": "選択したデータベースをリセットしますか？\n※アセットデータは削除されません。自動バックアップから復元可能です。",
     "Dialog.Confirmation.RemoveCommonAvatarGroup": "共通素体グループを削除しますか？\n共通素体グループ名: {0}",
     "Dialog.Confirmation.RemoveTempAvatar": "仮アバター名: {0}\n\n本当にこのアバターを削除しますか？",
-    "Dialog.Confirmation.ContinueRestoreFromBackup": "現在の設定のバックアップに失敗しましたが、バックアップからの復元処理を続行しますか？",
     "Dialog.Confirmation.RemovePreset": "プリセット名: {0}\n\n本当にこのプリセットを削除しますか？",
     "Dialog.Confirmation.AddToExistingItem": "同じBoothIdのアイテムが既に追加されています。そのアイテムにファイルやフォルダを追加しますか？",
     "Dialog.Confirmation.ResolveTempAvatar": "仮アバター「{0}」を\n正式アイテム「{1}」として確定しますか？",

--- a/AvatarExplorer.Core/Data/Localization/ko-KR.json
+++ b/AvatarExplorer.Core/Data/Localization/ko-KR.json
@@ -51,7 +51,6 @@
     "Dialog.Confirmation.ResetDatabase": "선택한 데이터베이스를 초기화하시겠습니까?\n※ 자산 데이터는 삭제되지 않습니다. 자동 백업에서 복원할 수 있습니다.",
     "Dialog.Confirmation.RemoveCommonAvatarGroup": "공통 바디 그룹을 삭제하시겠습니까?\n공통 바디 그룹 이름: {0}",
     "Dialog.Confirmation.RemoveTempAvatar": "임시 아바타 이름: {0}\n\n정말로 이 아바타를 삭제하시겠습니까?",
-    "Dialog.Confirmation.ContinueRestoreFromBackup": "현재 설정 백업에 실패했지만, 백업에서 복원을 계속하시겠습니까?",
     "Dialog.Confirmation.RemovePreset": "프리셋 이름: {0}\n\n정말로 이 프리셋을 삭제하시겠습니까?",
     "Dialog.Confirmation.AddToExistingItem": "같은 Booth ID의 아이템이 이미 추가되어 있습니다. 해당 아이템에 파일이나 폴더를 추가하시겠습니까?",
     "Dialog.Confirmation.ResolveTempAvatar": "임시 아바타 \"{0}\"를\n정식 아이템 \"{1}\"으로 확정하시겠습니까?",

--- a/AvatarExplorer.Core/Data/Localization/zh-CN.json
+++ b/AvatarExplorer.Core/Data/Localization/zh-CN.json
@@ -51,7 +51,6 @@
     "Dialog.Confirmation.ResetDatabase": "确定要重置选中的数据库吗？\n※ 资产数据不会被删除，可从自动备份中恢复。",
     "Dialog.Confirmation.RemoveCommonAvatarGroup": "要删除共通素体组吗？\n共通素体组名称: {0}",
     "Dialog.Confirmation.RemoveTempAvatar": "临时头像名称: {0}\n\n确定要删除这个头像吗？",
-    "Dialog.Confirmation.ContinueRestoreFromBackup": "当前设置的备份失败了，但仍要继续从备份恢复吗？",
     "Dialog.Confirmation.RemovePreset": "预设名称: {0}\n\n确定要删除这个预设吗？",
     "Dialog.Confirmation.AddToExistingItem": "已添加具有相同 Booth ID 的项目。要向该项目添加文件或文件夹吗？",
     "Dialog.Confirmation.ResolveTempAvatar": "要将临时头像“{0}”\n确定为正式项目“{1}”吗？",

--- a/AvatarExplorer.Core/Data/Localization/zh-TW.json
+++ b/AvatarExplorer.Core/Data/Localization/zh-TW.json
@@ -51,7 +51,6 @@
     "Dialog.Confirmation.ResetDatabase": "確定要重設選中的資料庫嗎？\n※ 資產資料不會被刪除，可以從自動備份還原。",
     "Dialog.Confirmation.RemoveCommonAvatarGroup": "要刪除共通素體群組嗎？\n共通素體群組名稱: {0}",
     "Dialog.Confirmation.RemoveTempAvatar": "暫時頭像名稱: {0}\n\n確定要刪除此頭像嗎？",
-    "Dialog.Confirmation.ContinueRestoreFromBackup": "目前設定的備份失敗了，但仍要繼續從備份還原嗎？",
     "Dialog.Confirmation.RemovePreset": "預設名稱: {0}\n\n確定要刪除此預設嗎？",
     "Dialog.Confirmation.AddToExistingItem": "已新增具有相同 Booth ID 的項目。要向該項目新增檔案或資料夾嗎？",
     "Dialog.Confirmation.ResolveTempAvatar": "要將暫時頭像「{0}」\n確定為正式項目「{1}」嗎？",

--- a/AvatarExplorer.Core/Localization/LocalizationKeys.g.cs
+++ b/AvatarExplorer.Core/Localization/LocalizationKeys.g.cs
@@ -106,7 +106,6 @@ public static class Loc
             public const string ResetDatabase = "Dialog.Confirmation.ResetDatabase";
             public const string RemoveCommonAvatarGroup = "Dialog.Confirmation.RemoveCommonAvatarGroup";
             public const string RemoveTempAvatar = "Dialog.Confirmation.RemoveTempAvatar";
-            public const string ContinueRestoreFromBackup = "Dialog.Confirmation.ContinueRestoreFromBackup";
             public const string RemovePreset = "Dialog.Confirmation.RemovePreset";
             public const string AddToExistingItem = "Dialog.Confirmation.AddToExistingItem";
             public const string ResolveTempAvatar = "Dialog.Confirmation.ResolveTempAvatar";

--- a/AvatarExplorer.UI/ViewModels/Overlays/SettingsViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/SettingsViewModel.cs
@@ -261,12 +261,6 @@ public class SettingsViewModel : ViewModelBase, IInitializable
         var folders = await StorageService.OpenFolderDialog(TopLevelProvider.Current, "Select Items Folder");
         if (folders == null || folders.Length == 0) return;
 
-        var result = await MainWindowViewModel.Instance.ShowYesNoDialog(
-            Localizer.Instance[Loc.Dialog.Confirmation.Default],
-            Localizer.Instance[Loc.Dialog.Confirmation.ContinueRestoreFromBackup]
-        );
-        if (!result) return;
-
         var selectedBackupPath = folders[0];
         await AvatarExplorerApp.Instance.BackupManager.RestoreBackup(selectedBackupPath);
     }


### PR DESCRIPTION
The "continue restoring?" confirmation was shown even when the backup succeeded, since it was displayed unconditionally. Remove it along with the now-unused ContinueRestoreFromBackup localization key.