### PR TITLE
fix(avatars): restore sorting in overlay views

### DIFF
--- a/AvatarExplorer.UI/ViewModels/Overlays/EditCommonAvatarsViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/EditCommonAvatarsViewModel.cs
@@ -13,6 +13,9 @@ using AvatarExplorer.Core.Services.System.Repositories;
 using AvatarExplorer.UI.Factories;
 using AvatarExplorer.UI.Interfaces;
 using AvatarExplorer.UI.Localization;
+using AvatarExplorer.UI.Models.Settings;
+using AvatarExplorer.UI.Services.Sort;
+using AvatarExplorer.UI.Services.System;
 using AvatarExplorer.UI.ViewModels.Component;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
@@ -29,7 +32,7 @@ public class EditCommonAvatarsViewModel : ViewModelBase, IInitializable
 
     [Reactive] public string SearchText { get; set; } = string.Empty;
     [Reactive] public IEnumerable<ItemViewModel> Avatars { get; set; } = [];
-    private List<ItemViewModel> _allAvatars = [];
+    private IEnumerable<ItemViewModel> _allAvatars = [];
 
     public IReactiveCommand SelectItemCommand { get; }
 
@@ -42,6 +45,7 @@ public class EditCommonAvatarsViewModel : ViewModelBase, IInitializable
 
     private static ItemGroupService ItemService => AvatarExplorerApp.Instance.ItemGroupService;
     private static CommonAvatarRepository CommonAvatarRep => ItemService.CommonAvatarRepository;
+    private static UserPreferences UserPreferences => UserPreferencesService.Instance.Repository.Settings;
 
     public EditCommonAvatarsViewModel()
     {
@@ -193,8 +197,14 @@ public class EditCommonAvatarsViewModel : ViewModelBase, IInitializable
     private void RefleshAvatars()
     {
         var avatars = ItemService.GetAvatars(includeCommonAvatar: false, includeTempAvatar: true, rawIdentifier: true);
+        var sortedAvatars = ItemSortService.SortAvatars(
+            avatars,
+            UserPreferences.SortOrder,
+            UserPreferences.SortDirection,
+            UserPreferences.RemoveBrackets
+        );
 
-        _allAvatars = avatars
+        _allAvatars = sortedAvatars
             .Select(NavigationItemFactory.CreateFromNavigationable)
             .Select(i => i.Update())
             .ToList();

--- a/AvatarExplorer.UI/ViewModels/Overlays/ResolveTempAvatarViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/ResolveTempAvatarViewModel.cs
@@ -9,6 +9,9 @@ using AvatarExplorer.Core.Services.System;
 using AvatarExplorer.UI.Factories;
 using AvatarExplorer.UI.Interfaces;
 using AvatarExplorer.UI.Localization;
+using AvatarExplorer.UI.Models.Settings;
+using AvatarExplorer.UI.Services.Sort;
+using AvatarExplorer.UI.Services.System;
 using AvatarExplorer.UI.ViewModels.Component;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
@@ -28,6 +31,7 @@ public class ResolveTempAvatarViewModel : ViewModelBase, IInitializable
     private string? SelectedAvatar { get; set; } = null;
 
     private static ItemGroupService ItemService => AvatarExplorerApp.Instance.ItemGroupService;
+    private static UserPreferences UserPreferences => UserPreferencesService.Instance.Repository.Settings;
 
     public ResolveTempAvatarViewModel()
     {
@@ -54,8 +58,14 @@ public class ResolveTempAvatarViewModel : ViewModelBase, IInitializable
     private void RefreshAvatars()
     {
         var avatars = ItemService.GetAvatars(includeCommonAvatar: false, includeTempAvatar: true, rawIdentifier: true);
-
-        _allAvatars = avatars
+        var sortedAvatars = ItemSortService.SortAvatars(
+            avatars,
+            UserPreferences.SortOrder,
+            UserPreferences.SortDirection,
+            UserPreferences.RemoveBrackets
+        );
+        
+        _allAvatars = sortedAvatars
             .Select(NavigationItemFactory.CreateFromNavigationable)
             .Select(i => i.Update())
             .ToList();

--- a/AvatarExplorer.UI/ViewModels/Overlays/SelectAvatarsViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/SelectAvatarsViewModel.cs
@@ -9,6 +9,9 @@ using AvatarExplorer.Core.Services.System;
 using AvatarExplorer.UI.Factories;
 using AvatarExplorer.UI.Interfaces;
 using AvatarExplorer.UI.Localization;
+using AvatarExplorer.UI.Models.Settings;
+using AvatarExplorer.UI.Services.Sort;
+using AvatarExplorer.UI.Services.System;
 using AvatarExplorer.UI.ViewModels.Component;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
@@ -32,6 +35,7 @@ public class SelectAvatarsViewModel : ViewModelBase, IInitializable
     public IReactiveCommand ConfirmCommand { get; }
 
     private static ItemGroupService ItemService => AvatarExplorerApp.Instance.ItemGroupService;
+    private static UserPreferences UserPreferences => UserPreferencesService.Instance.Repository.Settings;
 
     private bool IncludeCommonAvatar = false;
     private bool IncludeTempAvatar = true;
@@ -86,8 +90,14 @@ public class SelectAvatarsViewModel : ViewModelBase, IInitializable
     private void RefleshAvatars(bool includeCommonAvatar, bool includeTempAvatar)
     {
         var avatars = ItemService.GetAvatars(includeCommonAvatar, includeTempAvatar, rawIdentifier: true);
+        var sortedAvatars = ItemSortService.SortAvatars(
+            avatars,
+            UserPreferences.SortOrder,
+            UserPreferences.SortDirection,
+            UserPreferences.RemoveBrackets
+        );
 
-        _allAvatars = avatars
+        _allAvatars = sortedAvatars
             .Select(NavigationItemFactory.CreateFromNavigationable)
             .Select(i => i.Update())
             .ToList();


### PR DESCRIPTION
Add ItemSortService.SortAvatars() calls to EditCommonAvatars, ResolveTempAvatar, and SelectAvatars ViewModels. These views were displaying avatars in unsorted order instead of respecting user preferences for sort order, direction, and bracket removal.