### PR TITLE
fix(navigation): display empty folders in item folder view

### DIFF
--- a/AvatarExplorer.Core/Services/Items/ItemNavigationService.cs
+++ b/AvatarExplorer.Core/Services/Items/ItemNavigationService.cs
@@ -172,15 +172,19 @@ public class ItemNavigationService
     private IIdentifiable[] HandleItem(string state)
     {
         var itemFiles = PopulatePathCache(state);
+        var allFolders = _items.ItemRepository.EnumerateItemFolders(GetItemId()!);
 
-        return itemFiles.GroupBy(i => i.ParentFolderPath).Select(i =>
+        foreach (var folder in allFolders)
+            _pathCache[PathUtils.ComputeHash(folder)] = folder;
+
+        return allFolders.Select(folder =>
         {
-            var hash = PathUtils.ComputeHash(i.Key);
-            return new Folder(GetPrefix(FolderPrefix, hash), i.Key)
+            var hash = PathUtils.ComputeHash(folder);
+            return new Folder(GetPrefix(FolderPrefix, hash), folder)
             {
-                Title = Path.GetFileName(i.Key),
+                Title = Path.GetFileName(folder),
                 TitleLocalizable = false,
-                ItemCount = i.Count()
+                ItemCount = itemFiles.Count(f => f.ParentFolderPath == folder)
             };
         }).ToArray<IIdentifiable>();
     }
@@ -258,9 +262,6 @@ public class ItemNavigationService
 
         foreach (var file in itemFiles)
             _pathCache[PathUtils.ComputeHash(file.FilePath)] = file.FilePath;
-
-        foreach (var group in itemFiles.GroupBy(i => i.ParentFolderPath))
-            _pathCache[PathUtils.ComputeHash(group.Key)] = group.Key;
 
         return itemFiles;
     }

--- a/AvatarExplorer.Core/Services/System/Repositories/ItemRepository.cs
+++ b/AvatarExplorer.Core/Services/System/Repositories/ItemRepository.cs
@@ -186,6 +186,24 @@ public class ItemRepository : RepositoryBase<Item>
             .ThenBy(kvp => kvp.Key);
     }
 
+    public List<string> EnumerateItemFolders(string id)
+    {
+        var item = Get(id);
+        if (item == null) return [];
+
+        var folders = new List<string>();
+        var root = item.ItemPath;
+
+        if (Directory.Exists(root))
+            foreach (var dir in Directory.GetDirectories(root))
+                folders.Add(dir);
+
+        foreach (var path in item.ItemPaths)
+            folders.Add(path);
+
+        return folders;
+    }
+
     public List<ItemFile> EnumerateItemFiles(string id)
     {
         var item = Get(id);


### PR DESCRIPTION
- Add ItemRepository.EnumerateItemFolders to return all folders including empty ones
- Update HandleItem to use EnumerateItemFolders instead of deriving folders from files
- Remove redundant GroupBy folder caching from PopulatePathCache

Fixes #619 