### PR TITLE
feat(ui): add "nothing found" message when no main items

### DIFF
--- a/AvatarExplorer.UI/ViewModels/MainViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/MainViewModel.cs
@@ -50,6 +50,7 @@ public class MainViewModel : ViewModelBase, IInitializable, IPostInitializable
     [Reactive] public int SelectedCategory { get; set; } = 0;
     [Reactive] public IEnumerable<ItemViewModel> LeftItems { get; set; } = [];
     [Reactive] public IEnumerable<ItemViewModel> MainItems { get; set; } = [];
+    [Reactive] public bool IsMainItemsEmpty { get; set; }
 
     [Reactive] public PanelPageInfo LeftPageInfo { get; set; } = new();
     [Reactive] public PanelPageInfo RightPageInfo { get; set; } = new();
@@ -417,6 +418,8 @@ public class MainViewModel : ViewModelBase, IInitializable, IPostInitializable
         MainItems = RightPageInfo.GetPageItems(_allMainItems)
             .Select(i => i.Update(UserPreferences.NormalIconSize, UserPreferences.RemoveBrackets))
             .ToList();
+
+        IsMainItemsEmpty = !MainItems.Any();
     }
     #endregion
 

--- a/AvatarExplorer.UI/Views/MainView.axaml
+++ b/AvatarExplorer.UI/Views/MainView.axaml
@@ -200,7 +200,7 @@
 
                 <Border Grid.Column="2" Classes="panelbackground">
                     <Panel>
-                        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="10" IsVisible="False">
+                        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="10" IsVisible="{Binding IsMainItemsEmpty}">
                             <Image Source="avares://AvatarExplorer/Assets/Internal/EmptyIcon.png" Width="150" Height="150" HorizontalAlignment="Center" VerticalAlignment="Center"/>
                             <TextBlock Text="{Binding [Error.Nothing], Source={x:Static loc:Localizer.Instance}}" HorizontalAlignment="Center" VerticalAlignment="Center" FontWeight="Bold" FontSize="25" Foreground="{DynamicResource Text.Primary}"/>
                         </StackPanel>


### PR DESCRIPTION
Shows an EmptyIcon and localized error message when MainItems collection is empty, providing clear feedback to users instead of showing blank space.

Fixes #623 