### PR TITLE
fix(ui): restore page and scroll position when navigating from search screen

### DIFF
--- a/AvatarExplorer.UI/ViewModels/MainViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/MainViewModel.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
-using System.Reactive;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
 using Avalonia;
@@ -100,6 +99,9 @@ public class MainViewModel : ViewModelBase, IInitializable, IPostInitializable
 
     private string? _searchItemBaseState;
     private bool _hasSearchItem;
+
+    private readonly Guid _preSearchStateGuid = Guid.NewGuid();
+    private bool _isPreviousScreenSearch = false;
 
     private static UserPreferences UserPreferences => UserPreferencesService.Instance.Repository.Settings;
     #endregion
@@ -300,6 +302,13 @@ public class MainViewModel : ViewModelBase, IInitializable, IPostInitializable
 
     private void RefreshSearchResults(string searchQuery)
     {
+        // 前の画面が普通の画面だった時に復元できるよう、検索画面に入る前の状態を保存する
+        if (!_isPreviousScreenSearch)
+        {
+            _stateCacheManager.SaveRightState(RightPageInfo, _preSearchStateGuid);
+            _isPreviousScreenSearch = true;
+        }
+
         var sortOrder = UserPreferences.SortOrder;
         var sortDirection = UserPreferences.SortDirection;
 
@@ -313,11 +322,10 @@ public class MainViewModel : ViewModelBase, IInitializable, IPostInitializable
 
         RightPageInfo.TotalItems = _allMainItems.Count;
 
-        if (_searchManager.IsRestored)
+        if (_searchManager.IsRestoring)
         {
-            _searchManager.ClearRestoredFlag();
-            var clampedPage = Math.Min(RightPageInfo.CurrentPage, Math.Max(0, RightPageInfo.TotalPages - 1));
-            RightPageInfo.SetPage(clampedPage);
+            _searchManager.RestorePageInfo(RightPageInfo);
+            _searchManager.MarkAsRestored();
         }
         else
         {
@@ -357,6 +365,13 @@ public class MainViewModel : ViewModelBase, IInitializable, IPostInitializable
 
         PathSegments = new ObservableCollection<PathSegment>(
             BuildPathSegments(_itemNavigationService.GetCurrentSelectionNodes().Select(i => i.Value)));
+
+        // 検索画面から戻ってきたときに前の状態を復元する（検索中のアイテムから先に進んだ時に上書きされるのを防ぐため、_hasSearchItemがtrueのときは復元しない）
+        if (_isPreviousScreenSearch && !_hasSearchItem)
+        {
+            _stateCacheManager.RestoreRightState(RightPageInfo, _preSearchStateGuid);
+            _isPreviousScreenSearch = false;
+        }
     }
 
     private static IEnumerable<Item> SortNavigationItems(List<Item> items, ItemSortOrder sortOrder, SortDirection sortDirection, ImplementedSort implementedSort, string? avatarId)
@@ -606,7 +621,8 @@ public class MainViewModel : ViewModelBase, IInitializable, IPostInitializable
                 if (_hasSearchItem && currentState == _searchItemBaseState)
                 {
                     // 検索アイテムがpopされた → 検索状態を復元
-                    _searchManager.TryRestoreQuery(RightPageInfo);
+                    _searchManager.MarkAsRestoring();
+                    _searchManager.TryRestoreQuery();
                     _hasSearchItem = false;
                 }
                 else

--- a/AvatarExplorer.UI/ViewModels/Managers/SearchManager.cs
+++ b/AvatarExplorer.UI/ViewModels/Managers/SearchManager.cs
@@ -28,7 +28,7 @@ public class SearchManager
     private Vector _suspendedScrollOffset;
 
     public string? ActiveSearchQuery { get; private set; }
-    public bool IsRestored { get; private set; }
+    public bool IsRestoring { get; private set; }
     public bool HasSuspendedQuery => _suspendedSearchQuery != null;
 
     public string? ActiveSearchQueryDisplayText
@@ -74,16 +74,20 @@ public class SearchManager
         ActiveSearchQuery = null;
     }
 
-    public bool TryRestoreQuery(PanelPageInfo rightPageInfo)
+    public bool TryRestoreQuery()
     {
         if (_suspendedSearchQuery == null) return false;
 
         ActiveSearchQuery = _suspendedSearchQuery;
         _suspendedSearchQuery = null;
-        IsRestored = true;
+        return true;
+    }
+
+    public void RestorePageInfo(PanelPageInfo rightPageInfo)
+    {
+        if (!IsRestoring) return; // Only restore if we are in the restoring state
         rightPageInfo.CurrentPage = _suspendedPage;
         rightPageInfo.RestoreScrollOffset = _suspendedScrollOffset;
-        return true;
     }
 
     public void ClearSuspendedQuery()
@@ -91,10 +95,8 @@ public class SearchManager
         _suspendedSearchQuery = null;
     }
 
-    public void ClearRestoredFlag()
-    {
-        IsRestored = false;
-    }
+    public void MarkAsRestored() => IsRestoring = false;
+    public void MarkAsRestoring() => IsRestoring = true;
 
     public IEnumerable<Item> SearchItems(string query)
     {

--- a/AvatarExplorer.UI/ViewModels/Managers/StateCacheManager.cs
+++ b/AvatarExplorer.UI/ViewModels/Managers/StateCacheManager.cs
@@ -40,17 +40,17 @@ public class StateCacheManager
         }
     }
 
-    public void SaveRightState(PanelPageInfo rightPageInfo)
+    public void SaveRightState(PanelPageInfo rightPageInfo, Guid? customGuid = null)
     {
-        var currentGuid = _navigationService.CurrentStateId ?? Guid.Empty;
+        var currentGuid = customGuid ?? _navigationService.CurrentStateId ?? Guid.Empty;
 
         _pageCache.Add(currentGuid, rightPageInfo.CurrentPage);
         _scrollValueCache.Add(currentGuid, rightPageInfo.ScrollOffset);
     }
 
-    public void RestoreRightState(PanelPageInfo rightPageInfo)
+    public void RestoreRightState(PanelPageInfo rightPageInfo, Guid? customGuid = null)
     {
-        var currentGuid = _navigationService.CurrentStateId ?? Guid.Empty;
+        var currentGuid = customGuid ?? _navigationService.CurrentStateId ?? Guid.Empty;
         if (_pageCache.TryGetValue(currentGuid, out var page))
         {
             rightPageInfo.CurrentPage = page;


### PR DESCRIPTION
- Fix page position not restored when returning to search screen
- Fix original page and scroll position not restored when undoing from search
- Refactor SearchManager to use explicit restoring state machine
- Enhance StateCacheManager to support custom GUID for state tracking

Fixes #646 