### PR TITLE
fix(ui): prevent invalid tag selection when opening editor with no tags

### DIFF
--- a/AvatarExplorer.UI/ViewModels/Overlays/TagEditorViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/TagEditorViewModel.cs
@@ -58,8 +58,8 @@ public class TagEditorViewModel : ViewModelBase, IInitializable
     public void Open()
     {
         RefleshExistTags();
-        SelectedTagIndex = 0;
         SearchText = string.Empty;
+        SelectedTagIndex = ExistTags.Any() ? 0 : -1;
         IsVisible = true;
     }
 


### PR DESCRIPTION
Set SelectedTagIndex to -1 when no existing tags are present instead of hardcoding 0, which caused an out-of-range selection on the tag ComboBox.