### PR TITLE
fix(localization): clarify FileCategory.Material label applies to unitypackage files

### DIFF
--- a/AvatarExplorer.Core/Data/Localization/en-US.json
+++ b/AvatarExplorer.Core/Data/Localization/en-US.json
@@ -94,7 +94,7 @@
     "FileCategory.Texture": "Texture",
     "FileCategory.Document": "Document",
     "FileCategory.Unitypackage": "Unitypackage",
-    "FileCategory.Material": "Material",
+    "FileCategory.Material": "Material (Unitypackage)",
     "FileCategory.UrlShortcut": "URL Shortcut",
     "FileCategory.Font": "Font",
     "FileCategory.Unknown": "Unknown",

--- a/AvatarExplorer.Core/Data/Localization/es-ES.json
+++ b/AvatarExplorer.Core/Data/Localization/es-ES.json
@@ -94,7 +94,7 @@
     "FileCategory.Texture": "Textura",
     "FileCategory.Document": "Documento",
     "FileCategory.Unitypackage": "Unitypackage",
-    "FileCategory.Material": "Material",
+    "FileCategory.Material": "Material (Unitypackage)",
     "FileCategory.UrlShortcut": "Acceso directo URL",
     "FileCategory.Font": "Fuente",
     "FileCategory.Unknown": "Desconocido",

--- a/AvatarExplorer.Core/Data/Localization/fr-FR.json
+++ b/AvatarExplorer.Core/Data/Localization/fr-FR.json
@@ -94,7 +94,7 @@
     "FileCategory.Texture": "Texture",
     "FileCategory.Document": "Document",
     "FileCategory.Unitypackage": "Unitypackage",
-    "FileCategory.Material": "Matériau",
+    "FileCategory.Material": "Matériau (Unitypackage)",
     "FileCategory.UrlShortcut": "Raccourci URL",
     "FileCategory.Font": "Police",
     "FileCategory.Unknown": "Inconnu",

--- a/AvatarExplorer.Core/Data/Localization/ja-JP.json
+++ b/AvatarExplorer.Core/Data/Localization/ja-JP.json
@@ -94,7 +94,7 @@
     "FileCategory.Texture": "テクスチャ",
     "FileCategory.Document": "ドキュメント",
     "FileCategory.Unitypackage": "Unitypackage",
-    "FileCategory.Material": "マテリアル",
+    "FileCategory.Material": "マテリアル (Unitypackage)",
     "FileCategory.UrlShortcut": "URLショートカット",
     "FileCategory.Font": "フォント",
     "FileCategory.Unknown": "不明",

--- a/AvatarExplorer.Core/Data/Localization/ko-KR.json
+++ b/AvatarExplorer.Core/Data/Localization/ko-KR.json
@@ -94,7 +94,7 @@
     "FileCategory.Texture": "텍스처",
     "FileCategory.Document": "문서",
     "FileCategory.Unitypackage": "Unitypackage",
-    "FileCategory.Material": "재질",
+    "FileCategory.Material": "재질 (Unitypackage)",
     "FileCategory.UrlShortcut": "URL 바로가기",
     "FileCategory.Font": "폰트",
     "FileCategory.Unknown": "알 수 없음",

--- a/AvatarExplorer.Core/Data/Localization/zh-CN.json
+++ b/AvatarExplorer.Core/Data/Localization/zh-CN.json
@@ -94,7 +94,7 @@
     "FileCategory.Texture": "纹理",
     "FileCategory.Document": "文档",
     "FileCategory.Unitypackage": "Unitypackage",
-    "FileCategory.Material": "材质",
+    "FileCategory.Material": "材质 (Unitypackage)",
     "FileCategory.UrlShortcut": "URL 快捷方式",
     "FileCategory.Font": "字体",
     "FileCategory.Unknown": "未知",

--- a/AvatarExplorer.Core/Data/Localization/zh-TW.json
+++ b/AvatarExplorer.Core/Data/Localization/zh-TW.json
@@ -94,7 +94,7 @@
     "FileCategory.Texture": "材質",
     "FileCategory.Document": "文件",
     "FileCategory.Unitypackage": "Unitypackage",
-    "FileCategory.Material": "材質",
+    "FileCategory.Material": "材質 (Unitypackage)",
     "FileCategory.UrlShortcut": "URL 捷徑",
     "FileCategory.Font": "字型",
     "FileCategory.Unknown": "未知",


### PR DESCRIPTION
Update the display name in all 7 language files so users understand this category matches Unitypackage files whose filename contains "Material".