### PR TITLE
feat(ui): persist initial setup completion in user preferences

### DIFF
--- a/AvatarExplorer.UI/Models/Settings/UserPreferences.cs
+++ b/AvatarExplorer.UI/Models/Settings/UserPreferences.cs
@@ -20,4 +20,5 @@ public record UserPreferences
     public ItemSortOrder SortOrder { get; init; } = ItemSortOrder.UpdatedDate;
     public SortDirection SortDirection { get; init; } = SortDirection.Descending;
     public ImplementedSort ImplementedSort { get; init; } = ImplementedSort.None;
+    public bool InitialSetupCompleted { get; init; } = false;
 }

--- a/AvatarExplorer.UI/ViewModels/Overlays/InitialSetupViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/InitialSetupViewModel.cs
@@ -84,7 +84,7 @@ public class InitialSetupViewModel : ViewModelBase, IInitializable, IPostInitial
         IsVisible = false;
     }
 
-    private void MarkInitialSetupCompleted() =>
+    private static void MarkInitialSetupCompleted() =>
         UserPreferences.Update(UserPreferences.Settings with { InitialSetupCompleted = true });
 
     private static async void ShowSchemeRegistrationDialog()

--- a/AvatarExplorer.UI/ViewModels/Overlays/InitialSetupViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/InitialSetupViewModel.cs
@@ -10,6 +10,7 @@ using AvatarExplorer.Core.Services.System.Repositories;
 using AvatarExplorer.Core.Utils;
 using AvatarExplorer.UI.Interfaces;
 using AvatarExplorer.UI.Localization;
+using AvatarExplorer.UI.Services.System;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
 
@@ -26,6 +27,7 @@ public class InitialSetupViewModel : ViewModelBase, IInitializable, IPostInitial
     public IReactiveCommand CloseCommand { get; }
 
     private static RuntimeSettingsRepository Settings => AvatarExplorerApp.Instance.RuntimeSettings;
+    private static UserPreferencesRepository UserPreferences => UserPreferencesService.Instance.Repository;
 
     public InitialSetupViewModel()
     {
@@ -54,11 +56,16 @@ public class InitialSetupViewModel : ViewModelBase, IInitializable, IPostInitial
 
     public async Task OnInitialized()
     {
-        if (!AvatarExplorerApp.Instance.Items.GetAll().Any())
+        if (UserPreferences.Settings.InitialSetupCompleted) return;
+
+        if (AvatarExplorerApp.Instance.Items.GetAll().Any())
         {
-            Open();
-            ShowSchemeRegistrationDialog();
+            MarkInitialSetupCompleted();
+            return;
         }
+
+        Open();
+        ShowSchemeRegistrationDialog();
     }
 
     public void Open()
@@ -73,8 +80,12 @@ public class InitialSetupViewModel : ViewModelBase, IInitializable, IPostInitial
 
     private void Close()
     {
+        MarkInitialSetupCompleted();
         IsVisible = false;
     }
+
+    private void MarkInitialSetupCompleted() =>
+        UserPreferences.Update(UserPreferences.Settings with { InitialSetupCompleted = true });
 
     private static async void ShowSchemeRegistrationDialog()
     {

--- a/AvatarExplorer.UI/ViewModels/Overlays/SettingsViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/SettingsViewModel.cs
@@ -183,9 +183,12 @@ public class SettingsViewModel : ViewModelBase, IInitializable
         };
     }
 
-    public UserPreferences CreateUserPreferences()
+    private void OnApply()
     {
-        return new UserPreferences
+        AvatarExplorerApp.Instance.RuntimeSettings.Update(CreateRuntimeSettings());
+
+        var current = UserPreferencesService.Instance.Repository.Settings;
+        UserPreferencesService.Instance.Repository.Update(current with
         {
             Language = SelectedLanguage,
             Theme = (Theme)SelectedTheme,
@@ -202,13 +205,7 @@ public class SettingsViewModel : ViewModelBase, IInitializable
             SortOrder = (ItemSortOrder)SelectedSortOrder,
             SortDirection = SelectedSortDirection,
             ImplementedSort = (ImplementedSort)SelectedImplementedSort
-        };
-    }
-
-    private void OnApply()
-    {
-        AvatarExplorerApp.Instance.RuntimeSettings.Update(CreateRuntimeSettings());
-        UserPreferencesService.Instance.Repository.Update(CreateUserPreferences());
+        });
     }
 
     private void OnClose()


### PR DESCRIPTION
Track whether the initial setup has been completed via the new InitialSetupCompleted preference instead of relying solely on the absence of items. The flag is set when setup is closed, or immediately on startup when items already exist, so the setup overlay only appears once.

Closes #667 