### PR TITLE
feat(ui): add variation hash database to reset options

### DIFF
--- a/AvatarExplorer.Core/Data/Localization/en-US.json
+++ b/AvatarExplorer.Core/Data/Localization/en-US.json
@@ -474,6 +474,7 @@
     "ResetDatabase.TempAvatarDatabase": "Temp Avatar Database",
     "ResetDatabase.CommonAvatarDatabase": "Common Avatar Database",
     "ResetDatabase.BulkImportPresetDatabase": "Bulk Import Preset Database",
+    "ResetDatabase.VariationHashDatabase": "Variation Hash Database",
     "ResetDatabase.Reset": "Reset",
 
     "FetchAllThumbnails.Title": "Bulk Thumbnail Fetch",

--- a/AvatarExplorer.Core/Data/Localization/es-ES.json
+++ b/AvatarExplorer.Core/Data/Localization/es-ES.json
@@ -474,6 +474,7 @@
     "ResetDatabase.TempAvatarDatabase": "Base de datos de avatares temporales",
     "ResetDatabase.CommonAvatarDatabase": "Base de datos de avatares comunes",
     "ResetDatabase.BulkImportPresetDatabase": "Base de datos de ajustes preestablecidos de importación masiva",
+    "ResetDatabase.VariationHashDatabase": "Base de datos de hash de variaciones",
     "ResetDatabase.Reset": "Reiniciar",
 
     "FetchAllThumbnails.Title": "Obtención masiva de miniaturas",

--- a/AvatarExplorer.Core/Data/Localization/fr-FR.json
+++ b/AvatarExplorer.Core/Data/Localization/fr-FR.json
@@ -474,6 +474,7 @@
     "ResetDatabase.TempAvatarDatabase": "Base de données des avatars temporaires",
     "ResetDatabase.CommonAvatarDatabase": "Base de données des avatars communs",
     "ResetDatabase.BulkImportPresetDatabase": "Base de données des préréglages d'importation en masse",
+    "ResetDatabase.VariationHashDatabase": "Base de données des hachages de variantes",
     "ResetDatabase.Reset": "Réinitialiser",
 
     "FetchAllThumbnails.Title": "Récupération groupée des vignettes",

--- a/AvatarExplorer.Core/Data/Localization/ja-JP.json
+++ b/AvatarExplorer.Core/Data/Localization/ja-JP.json
@@ -474,6 +474,7 @@
     "ResetDatabase.TempAvatarDatabase": "仮登録アバターデータベース",
     "ResetDatabase.CommonAvatarDatabase": "共通素体データベース",
     "ResetDatabase.BulkImportPresetDatabase": "一括インポートプリセットデータベース",
+    "ResetDatabase.VariationHashDatabase": "バリエーションハッシュデータベース",
     "ResetDatabase.Reset": "リセット",
 
     "FetchAllThumbnails.Title": "サムネイル一括取得",

--- a/AvatarExplorer.Core/Data/Localization/ko-KR.json
+++ b/AvatarExplorer.Core/Data/Localization/ko-KR.json
@@ -474,6 +474,7 @@
     "ResetDatabase.TempAvatarDatabase": "임시 아바타 데이터베이스",
     "ResetDatabase.CommonAvatarDatabase": "공통 바디 데이터베이스",
     "ResetDatabase.BulkImportPresetDatabase": "일괄 가져오기 프리셋 데이터베이스",
+    "ResetDatabase.VariationHashDatabase": "변형 해시 데이터베이스",
     "ResetDatabase.Reset": "초기화",
 
     "FetchAllThumbnails.Title": "썸네일 일괄 가져오기",

--- a/AvatarExplorer.Core/Data/Localization/zh-CN.json
+++ b/AvatarExplorer.Core/Data/Localization/zh-CN.json
@@ -474,6 +474,7 @@
     "ResetDatabase.TempAvatarDatabase": "临时头像数据库",
     "ResetDatabase.CommonAvatarDatabase": "共通素体数据库",
     "ResetDatabase.BulkImportPresetDatabase": "批量导入预设数据库",
+    "ResetDatabase.VariationHashDatabase": "变体哈希数据库",
     "ResetDatabase.Reset": "重置",
 
     "FetchAllThumbnails.Title": "批量获取缩略图",

--- a/AvatarExplorer.Core/Data/Localization/zh-TW.json
+++ b/AvatarExplorer.Core/Data/Localization/zh-TW.json
@@ -474,6 +474,7 @@
     "ResetDatabase.TempAvatarDatabase": "暫時頭像資料庫",
     "ResetDatabase.CommonAvatarDatabase": "共通素體資料庫",
     "ResetDatabase.BulkImportPresetDatabase": "批次匯入預設資料庫",
+    "ResetDatabase.VariationHashDatabase": "變體雜湊資料庫",
     "ResetDatabase.Reset": "重設",
 
     "FetchAllThumbnails.Title": "批次取得縮圖",

--- a/AvatarExplorer.Core/Localization/LocalizationKeys.g.cs
+++ b/AvatarExplorer.Core/Localization/LocalizationKeys.g.cs
@@ -783,6 +783,7 @@ public static class Loc
         public const string TempAvatarDatabase = "ResetDatabase.TempAvatarDatabase";
         public const string CommonAvatarDatabase = "ResetDatabase.CommonAvatarDatabase";
         public const string BulkImportPresetDatabase = "ResetDatabase.BulkImportPresetDatabase";
+        public const string VariationHashDatabase = "ResetDatabase.VariationHashDatabase";
         public const string Reset = "ResetDatabase.Reset";
     }
     public static class FetchAllThumbnails

--- a/AvatarExplorer.UI/ViewModels/Overlays/ResetDatabaseViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/ResetDatabaseViewModel.cs
@@ -15,6 +15,7 @@ public class ResetDatabaseViewModel : ViewModelBase
     [Reactive] public bool ResetTempAvatars { get; set; } = true;
     [Reactive] public bool ResetCommonAvatars { get; set; } = true;
     [Reactive] public bool ResetBulkImportPresets { get; set; } = true;
+    [Reactive] public bool ResetVariationHashes { get; set; } = true;
 
     public IReactiveCommand ResetCommand { get; }
     public IReactiveCommand CancelCommand { get; }
@@ -31,12 +32,13 @@ public class ResetDatabaseViewModel : ViewModelBase
         ResetTempAvatars = true;
         ResetCommonAvatars = true;
         ResetBulkImportPresets = true;
+        ResetVariationHashes = true;
         IsVisible = true;
     }
 
     private async Task Reset()
     {
-        if (!ResetItems && !ResetTempAvatars && !ResetCommonAvatars && !ResetBulkImportPresets) return;
+        if (!ResetItems && !ResetTempAvatars && !ResetCommonAvatars && !ResetBulkImportPresets && !ResetVariationHashes) return;
 
         var result = await MainWindowViewModel.Instance.ShowYesNoDialog(
             Localizer.Instance[Loc.Dialog.Confirmation.Default],
@@ -64,6 +66,11 @@ public class ResetDatabaseViewModel : ViewModelBase
         if (ResetBulkImportPresets)
         {
             AvatarExplorerApp.Instance.BulkImportPresets.Clear();
+        }
+
+        if (ResetVariationHashes)
+        {
+            AvatarExplorerApp.Instance.VariationHashes.Clear();
         }
 
         IsVisible = false;

--- a/AvatarExplorer.UI/Views/Overlays/ResetDatabaseOverlay.axaml
+++ b/AvatarExplorer.UI/Views/Overlays/ResetDatabaseOverlay.axaml
@@ -23,6 +23,7 @@
                         <CheckBox IsChecked="{Binding ResetTempAvatars}" Content="{Binding [ResetDatabase.TempAvatarDatabase], Source={x:Static loc:Localizer.Instance}}"/>
                         <CheckBox IsChecked="{Binding ResetCommonAvatars}" Content="{Binding [ResetDatabase.CommonAvatarDatabase], Source={x:Static loc:Localizer.Instance}}"/>
                         <CheckBox IsChecked="{Binding ResetBulkImportPresets}" Content="{Binding [ResetDatabase.BulkImportPresetDatabase], Source={x:Static loc:Localizer.Instance}}"/>
+                        <CheckBox IsChecked="{Binding ResetVariationHashes}" Content="{Binding [ResetDatabase.VariationHashDatabase], Source={x:Static loc:Localizer.Instance}}"/>
                     </StackPanel>
                 </StackPanel>
 


### PR DESCRIPTION
Add a Variation Hash Database checkbox to the database reset dialog so variation hashes can be cleared along with the other databases. Includes localization keys for all supported languages.

Fixes #663 