### PR TITLE
fix(import): preserve selected package on bulk import item update

### DIFF
--- a/AvatarExplorer.UI/ViewModels/Component/BulkImportItemViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Component/BulkImportItemViewModel.cs
@@ -63,10 +63,15 @@ public class BulkImportItemViewModel : ViewModelBase
             Title = TextBracketsUtils.RemoveBrackets(TitleRaw);
         }
 
-        UnitypackageViewModels = UnitypackageFullPaths.Select(path => new UnitypackageViewModel(path));
         var previousSelectedPackage = SelectedUnitypackage;
-        SelectedUnitypackage = -1;
-        SelectedUnitypackage = previousSelectedPackage;
+        UnitypackageViewModels = UnitypackageFullPaths.Select(path => new UnitypackageViewModel(path));
+
+        if (!UnitypackageViewModels.Any())
+            SelectedUnitypackage = -1;
+        else if (previousSelectedPackage < 0 || previousSelectedPackage >= UnitypackageViewModels.Count())
+            SelectedUnitypackage = 0;
+        else
+            SelectedUnitypackage = previousSelectedPackage;
 
         return this;
     }


### PR DESCRIPTION
Reassigning UnitypackageViewModels reset SelectedUnitypackage to -1 before it was captured into previousSelectedPackage, causing the selection to be lost during item updates. Capture the previous selection first and clamp the value with bounds checks so the selected package is preserved (reset to 0 when out of range, -1 when no packages remain).

Fixes #683 