### PR TITLE
feat(avatars): enable common avatar check for all categories

### DIFF
--- a/AvatarExplorer.Core/Data/Localization/en-US.json
+++ b/AvatarExplorer.Core/Data/Localization/en-US.json
@@ -193,7 +193,6 @@
     "Error.PresetNotFound": "Preset not found",
     "Error.Validation.EmptyTitle": "Item title field is empty",
     "Error.Validation.EmptyAuthor": "Item author field is empty",
-    "Error.Validation.NotClothingWithCommonAvatar": "Common avatars are only valid for clothing category. They will be invalid in the current selection.",
     "Error.ImportFailed": "Data import failed",
     "Error.ExportFailed": "Data export failed",
     "Error.ItemEditFailed": "Item edit failed",

--- a/AvatarExplorer.Core/Data/Localization/es-ES.json
+++ b/AvatarExplorer.Core/Data/Localization/es-ES.json
@@ -193,7 +193,6 @@
     "Error.PresetNotFound": "Ajuste preestablecido no encontrado",
     "Error.Validation.EmptyTitle": "El campo del título del elemento está vacío",
     "Error.Validation.EmptyAuthor": "El campo del autor del elemento está vacío",
-    "Error.Validation.NotClothingWithCommonAvatar": "Los avatares comunes solo son válidos para la categoría de ropa. No serán válidos en la selección actual.",
     "Error.ImportFailed": "La importación de datos falló",
     "Error.ExportFailed": "La exportación de datos falló",
     "Error.ItemEditFailed": "La edición del elemento falló",

--- a/AvatarExplorer.Core/Data/Localization/fr-FR.json
+++ b/AvatarExplorer.Core/Data/Localization/fr-FR.json
@@ -193,7 +193,6 @@
     "Error.PresetNotFound": "Préréglage introuvable",
     "Error.Validation.EmptyTitle": "Le champ du titre de l'élément est vide",
     "Error.Validation.EmptyAuthor": "Le champ de l'auteur de l'élément est vide",
-    "Error.Validation.NotClothingWithCommonAvatar": "Les avatars communs ne sont valides que pour la catégorie vêtements. Ils seront invalides dans la sélection actuelle.",
     "Error.ImportFailed": "L'importation des données a échoué",
     "Error.ExportFailed": "L'exportation des données a échoué",
     "Error.ItemEditFailed": "La modification de l'élément a échoué",

--- a/AvatarExplorer.Core/Data/Localization/ja-JP.json
+++ b/AvatarExplorer.Core/Data/Localization/ja-JP.json
@@ -193,7 +193,6 @@
     "Error.PresetNotFound": "プリセットが見つかりませんでした",
     "Error.Validation.EmptyTitle": "アイテムのタイトル欄が空です",
     "Error.Validation.EmptyAuthor": "アイテムの作者欄が空です",
-    "Error.Validation.NotClothingWithCommonAvatar": "共通素体は衣装カテゴリでのみ有効です。現在の選択では無効になります。",
     "Error.ImportFailed": "データのインポートに失敗しました",
     "Error.ExportFailed": "データのエクスポートに失敗しました",
     "Error.ItemEditFailed": "アイテムの編集に失敗しました",

--- a/AvatarExplorer.Core/Data/Localization/ko-KR.json
+++ b/AvatarExplorer.Core/Data/Localization/ko-KR.json
@@ -193,7 +193,6 @@
     "Error.PresetNotFound": "프리셋을 찾을 수 없습니다",
     "Error.Validation.EmptyTitle": "아이템 제목이 비어 있습니다",
     "Error.Validation.EmptyAuthor": "아이템 작성자가 비어 있습니다",
-    "Error.Validation.NotClothingWithCommonAvatar": "공통 바디는 의상 카테고리에서만 유효합니다. 현재 선택에서는 무효가 됩니다.",
     "Error.ImportFailed": "데이터 가져오기에 실패했습니다",
     "Error.ExportFailed": "데이터 내보내기에 실패했습니다",
     "Error.ItemEditFailed": "아이템 편집에 실패했습니다",

--- a/AvatarExplorer.Core/Data/Localization/zh-CN.json
+++ b/AvatarExplorer.Core/Data/Localization/zh-CN.json
@@ -193,7 +193,6 @@
     "Error.PresetNotFound": "未找到预设",
     "Error.Validation.EmptyTitle": "项目标题为空",
     "Error.Validation.EmptyAuthor": "项目作者为空",
-    "Error.Validation.NotClothingWithCommonAvatar": "共通素体仅对服装类别有效。当前选择将无效。",
     "Error.ImportFailed": "数据导入失败",
     "Error.ExportFailed": "数据导出失败",
     "Error.ItemEditFailed": "项目编辑失败",

--- a/AvatarExplorer.Core/Data/Localization/zh-TW.json
+++ b/AvatarExplorer.Core/Data/Localization/zh-TW.json
@@ -193,7 +193,6 @@
     "Error.PresetNotFound": "找不到預設",
     "Error.Validation.EmptyTitle": "項目標題為空",
     "Error.Validation.EmptyAuthor": "項目作者為空",
-    "Error.Validation.NotClothingWithCommonAvatar": "共通素體僅對服裝類別有效。於目前選擇下將無效。",
     "Error.ImportFailed": "資料匯入失敗",
     "Error.ExportFailed": "資料匯出失敗",
     "Error.ItemEditFailed": "項目編輯失敗",

--- a/AvatarExplorer.Core/Localization/LocalizationKeys.g.cs
+++ b/AvatarExplorer.Core/Localization/LocalizationKeys.g.cs
@@ -319,7 +319,6 @@ public static class Loc
         {
             public const string EmptyTitle = "Error.Validation.EmptyTitle";
             public const string EmptyAuthor = "Error.Validation.EmptyAuthor";
-            public const string NotClothingWithCommonAvatar = "Error.Validation.NotClothingWithCommonAvatar";
         }
         public const string ImportFailed = "Error.ImportFailed";
         public const string ExportFailed = "Error.ExportFailed";

--- a/AvatarExplorer.Core/Services/Avatars/Internal/AvatarStatusResolver.cs
+++ b/AvatarExplorer.Core/Services/Avatars/Internal/AvatarStatusResolver.cs
@@ -12,8 +12,6 @@ internal static class AvatarStatusResolver
         if ((!treatEmptySupportedAvatarAsNone && !item.SupportedAvatars.Any()) || item.SupportedAvatars.Contains(avatarId))
             result.IsSupported = true;
 
-        if (item.Category.Type != ItemType.Clothing) return result;
-
         // アイテムの対応アバターが共通素体グループで登録されていた時用の処理
         foreach (var id in item.SupportedAvatars)
         {

--- a/AvatarExplorer.UI/ViewModels/Overlays/ItemEditorViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/ItemEditorViewModel.cs
@@ -547,17 +547,6 @@ public class ItemEditorViewModel : ViewModelBase
             return false;
         }
 
-        // Supported Avatars
-        if (SelectedCategory.Category.Type != ItemType.Clothing && SupportedAvatars.Any(i => i.StartsWith("commonavatar")))
-        {
-            MainWindowViewModel.ShowNotification(
-                Localizer.Instance[Loc.Error.Default],
-                Localizer.Instance[Loc.Error.Validation.NotClothingWithCommonAvatar],
-                NotificationType.Error
-            );
-            return false;
-        }
-
         return true;
     }
 }


### PR DESCRIPTION
Remove the clothing-only category guard in AvatarStatusResolver so the common avatar group resolution runs for every category, and drop the ItemEditorViewModel validation that rejected commonavatar IDs for non-clothing categories. Remove the now-unused Error.Validation.NotClothingWithCommonAvatar localization key.

Closes #662 