### PR TITLE
refactor: centralize singleton access via InstanceRepository

### DIFF
--- a/.github/agents/code-reviewer.agent.md
+++ b/.github/agents/code-reviewer.agent.md
@@ -31,7 +31,7 @@ You are a **Code Reviewer specialist** for the AvatarExplorer project. Your job 
 - **Overlay Pattern**: Each overlay has a ViewModel in `ViewModels/Overlays/` and a View in `Views/Overlays/`
 - **Dialog Results**: Use `TaskCompletionSource`-style `WaitForResult()` async pattern
 - **Manager Pattern**: Complex logic extracted into `ViewModels/Managers/` (e.g., SidePanelManager, SearchManager)
-- **Singleton Access**: `MainWindowViewModel.Instance` / `MainViewModel.Instance` for cross-VM communication
+- **Singleton Access**: `InstanceRepository.MainWindow` / `MainViewModel.Instance` for cross-VM communication
 - **Compiled Bindings**: Enabled by default (`x:DataType` required in XAML)
 - **Private Fields**: Use `_camelCase` (e.g., `_tcs`, `_allAvatars`)
 

--- a/.opencode/agents/code-reviewer.md
+++ b/.opencode/agents/code-reviewer.md
@@ -37,7 +37,7 @@ You are a **Code Reviewer specialist** for the AvatarExplorer project. Your job 
 - **Overlay Pattern**: Each overlay has a ViewModel in `ViewModels/Overlays/` and a View in `Views/Overlays/`
 - **Dialog Results**: Use `TaskCompletionSource`-style `WaitForResult()` async pattern
 - **Manager Pattern**: Complex logic extracted into `ViewModels/Managers/` (e.g., SidePanelManager, SearchManager)
-- **Singleton Access**: `MainWindowViewModel.Instance` / `MainViewModel.Instance` for cross-VM communication
+- **Singleton Access**: `InstanceRepository.MainWindow` / `MainViewModel.Instance` for cross-VM communication
 - **Compiled Bindings**: Enabled by default (`x:DataType` required in XAML)
 - **Private Fields**: Use `_camelCase` (e.g., `_tcs`, `_allAvatars`)
 

--- a/AvatarExplorer.Core/Services/System/AvatarExplorerApp.cs
+++ b/AvatarExplorer.Core/Services/System/AvatarExplorerApp.cs
@@ -16,14 +16,17 @@ public class AvatarExplorerApp
 
     private bool _initialized = false;
 
-    public ItemRepository Items { get; } = new();
-    public CommonAvatarRepository CommonAvatars { get; } = new();
-    public TempAvatarRepository TempAvatars { get; } = new();
-    public BulkImportPresetRepository BulkImportPresets { get; } = new();
+    public ItemRepository ItemRepository { get; } = new();
+    public CommonAvatarRepository CommonAvatarRepository { get; } = new();
+    public TempAvatarRepository TempAvatarRepository { get; } = new();
+    public BulkImportPresetRepository BulkImportPresetRepository { get; } = new();
     public ItemGroupService ItemGroupService { get; }
     public ItemNavigationService ItemNavigationService { get; }
-    public RuntimeSettingsRepository RuntimeSettings { get; } = new();
-    public VariationHashRepository VariationHashes { get; } = new();
+    public RuntimeSettingsRepository RuntimeSettingsRepository { get; } = new();
+    public VariationHashRepository VariationHashRepository { get; } = new();
+
+    // Aliases for easier access
+    public RuntimeSettings RuntimeSettings => RuntimeSettingsRepository.Settings;
 
     public Func<ArchivePasswordRequest, ValueTask<string?>>? ArchivePasswordProvider { get; set; }
 
@@ -31,7 +34,7 @@ public class AvatarExplorerApp
 
     private AvatarExplorerApp()
     {
-        ItemGroupService = new(Items, CommonAvatars, TempAvatars, RuntimeSettings);
+        ItemGroupService = new(ItemRepository, CommonAvatarRepository, TempAvatarRepository, RuntimeSettingsRepository);
         ItemNavigationService = new(ItemGroupService);
     }
 
@@ -39,13 +42,13 @@ public class AvatarExplorerApp
     {
         if (_initialized) return;
 
-        RuntimeSettings.Load();
+        RuntimeSettingsRepository.Load();
 
-        Items.Load();
-        CommonAvatars.Load();
-        TempAvatars.Load();
-        BulkImportPresets.Load();
-        VariationHashes.Load();
+        ItemRepository.Load();
+        CommonAvatarRepository.Load();
+        TempAvatarRepository.Load();
+        BulkImportPresetRepository.Load();
+        VariationHashRepository.Load();
 
         ItemGroupService.RebuildIndices();
 
@@ -61,8 +64,8 @@ public class AvatarExplorerApp
         );
         BackupManager.OnBackupRestored += OnBackupRestored;
 
-        RuntimeSettings.OnSettingsChanged += OnRuntimeSettingsUpdated;
-        BackupManager.StartAutoBackup(RuntimeSettings.Settings.AutoBackupInterval, RuntimeSettings.Settings.AutoBackupRootDirectory);
+        RuntimeSettingsRepository.OnSettingsChanged += OnRuntimeSettingsUpdated;
+        BackupManager.StartAutoBackup(RuntimeSettings.AutoBackupInterval, RuntimeSettings.AutoBackupRootDirectory);
 
         ErrorManager.Instance.OnErrorOccured += ErrorLogWriter.Instance.Write;
         ErrorManager.Instance.OnInternalErrorOccured += ErrorLogWriter.Instance.InternalWrite;
@@ -72,13 +75,13 @@ public class AvatarExplorerApp
 
     public void OnBackupRestored()
     {
-        RuntimeSettings.Load();
+        RuntimeSettingsRepository.Load();
 
-        Items.Load();
-        CommonAvatars.Load();
-        TempAvatars.Load();
-        BulkImportPresets.Load();
-        VariationHashes.Load();
+        ItemRepository.Load();
+        CommonAvatarRepository.Load();
+        TempAvatarRepository.Load();
+        BulkImportPresetRepository.Load();
+        VariationHashRepository.Load();
 
         ItemGroupService.RebuildIndices();
     }

--- a/AvatarExplorer.Core/Services/System/Repositories/ItemRepository.cs
+++ b/AvatarExplorer.Core/Services/System/Repositories/ItemRepository.cs
@@ -18,7 +18,7 @@ public class ItemRepository : RepositoryBase<Item>
         DatabaseMigrationService.MigrateDatabase(
             Db.DatabaseFilePath,
             DatabaseMigrations.ItemVersion,
-            (items, version) => DatabaseMigrations.ApplyItemMigration(items, version, AvatarExplorerApp.Instance.RuntimeSettings.Settings.DataRootDirectory));
+            (items, version) => DatabaseMigrations.ApplyItemMigration(items, version, AvatarExplorerApp.Instance.RuntimeSettings.DataRootDirectory));
 
         Db.Load();
         Db.MigrationVersion = DatabaseMigrations.ItemVersion;
@@ -81,7 +81,7 @@ public class ItemRepository : RepositoryBase<Item>
     {
         try
         {
-            await AvatarExplorerApp.Instance.VariationHashes.EnsureVariationHash(itemId);
+            await AvatarExplorerApp.Instance.VariationHashRepository.EnsureVariationHash(itemId);
         }
         catch (Exception ex)
         {
@@ -144,7 +144,7 @@ public class ItemRepository : RepositoryBase<Item>
         var item = Get(identifier);
         if (item == null) return Error.NotFound(description: "Item not found.");
 
-        var settings = AvatarExplorerApp.Instance.RuntimeSettings.Settings;
+        var settings = AvatarExplorerApp.Instance.RuntimeSettings;
 
         var defaultExtractPath = string.IsNullOrEmpty(item.ItemPath) ? GetSafePath(item, settings.DataRootDirectory) : item.ItemPath;
         var result = await FileSystemService.ExtractItemPaths(defaultExtractPath, paths, shouldLinkToOriginal, settings.MaxDegreeOfParallelism, removeOriginal ?? settings.RemoveOriginal);

--- a/AvatarExplorer.Core/Utils/HashUtils.cs
+++ b/AvatarExplorer.Core/Utils/HashUtils.cs
@@ -9,11 +9,4 @@ public static class HashUtils
         var hashBytes = System.Security.Cryptography.SHA256.HashData(bytes);
         return Convert.ToHexStringLower(hashBytes);
     }
-
-    public static string CalculateStringsHash(IEnumerable<string> inputs)
-    {
-        if (inputs == null || !inputs.Any()) return string.Empty;
-        var combinedInput = string.Join("|", inputs);
-        return CalculateStringHash(combinedInput);
-    }
 }

--- a/AvatarExplorer.UI/Program.cs
+++ b/AvatarExplorer.UI/Program.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.IO;
 using System.Threading;
 using Avalonia;
 using AvatarExplorer.Core.Services.System;

--- a/AvatarExplorer.UI/Services/AppInitializer.cs
+++ b/AvatarExplorer.UI/Services/AppInitializer.cs
@@ -3,7 +3,6 @@ using AvatarExplorer.Core.Services.System;
 using AvatarExplorer.UI.Data.Paths;
 using AvatarExplorer.UI.Localization;
 using AvatarExplorer.UI.Services.ContextMenu;
-using AvatarExplorer.UI.Services.System;
 using AvatarExplorer.UI.Services.Utilities;
 
 namespace AvatarExplorer.UI.Services;

--- a/AvatarExplorer.UI/Services/AppInitializer.cs
+++ b/AvatarExplorer.UI/Services/AppInitializer.cs
@@ -27,7 +27,7 @@ public static class AppInitializer
 
     public static void InitializeUserPreferences()
     {
-        UserPreferencesService.Instance.Repository.Load();
+        InstanceRepository.UserPreferencesRepository.Load();
     }
 
     public static void StartThumbnailCacheWarmup()

--- a/AvatarExplorer.UI/Services/AppInitializer.cs
+++ b/AvatarExplorer.UI/Services/AppInitializer.cs
@@ -12,7 +12,7 @@ public static class AppInitializer
 {
     public static void InitializeApp()
     {
-        AvatarExplorerApp.Instance.Initialize();
+        InstanceRepository.App.Initialize();
     }
 
     public static void InitializeLocalization(string localizationFolderPath)
@@ -32,7 +32,7 @@ public static class AppInitializer
 
     public static void StartThumbnailCacheWarmup()
     {
-        var thumbnailFileNames = AvatarExplorerApp.Instance.Items.GetAll()
+        var thumbnailFileNames = InstanceRepository.Items.GetAll()
             .Select(i => i.ThumbnailFileName)
             .Where(p => !string.IsNullOrEmpty(p));
         ImageService.StartThumbnailCacheWarmupInBackground(thumbnailFileNames);
@@ -45,7 +45,7 @@ public static class AppInitializer
 
     public static void RegisterBackupFiles()
     {
-        AvatarExplorerApp.Instance.BackupManager.AddTargetFiles(
+        InstanceRepository.BackupManager.AddTargetFiles(
             [
                 UISystemPath.UserPreferencesFilePath
             ]

--- a/AvatarExplorer.UI/Services/ContextMenu/ContextMenuHandlerService.cs
+++ b/AvatarExplorer.UI/Services/ContextMenu/ContextMenuHandlerService.cs
@@ -7,11 +7,8 @@ using System.Threading.Tasks;
 using Avalonia.Controls.Notifications;
 using AvatarExplorer.Core.Localization;
 using AvatarExplorer.Core.Models.Items;
-using AvatarExplorer.Core.Models.System;
 using AvatarExplorer.Core.Services.IO;
-using AvatarExplorer.Core.Services.Items;
 using AvatarExplorer.Core.Services.System;
-using AvatarExplorer.Core.Services.System.Repositories;
 using AvatarExplorer.Core.Utils;
 using AvatarExplorer.UI.Localization;
 using AvatarExplorer.UI.Models.ContextMenu;
@@ -23,12 +20,7 @@ namespace AvatarExplorer.UI.Services.ContextMenu;
 
 public static class ContextMenuHandlerService
 {
-    private static readonly Dictionary<ActionKey, Action<string>> _handlers = new();
-
-    private static ItemRepository Items => AvatarExplorerApp.Instance.Items;
-    private static ItemGroupService ItemGroupService => AvatarExplorerApp.Instance.ItemGroupService;
-    private static ItemNavigationService ItemNavigationService => AvatarExplorerApp.Instance.ItemNavigationService;
-    private static RuntimeSettings RuntimeSettings => AvatarExplorerApp.Instance.RuntimeSettings.Settings;
+    private static readonly Dictionary<ActionKey, Action<string>> _handlers = [];
 
     public static void Register(ActionKey key, Action<string> handler)
     {
@@ -80,10 +72,10 @@ public static class ContextMenuHandlerService
 
     private static Item? GetByIdentifier(string identifier)
     {
-        var item = Items.Get(identifier);
+        var item = InstanceRepository.Items.Get(identifier);
         if (item == null)
         {
-            MainWindowViewModel.ShowNotification(
+            NotificationManager.Show(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.ItemNotFound],
                 NotificationType.Error
@@ -94,8 +86,8 @@ public static class ContextMenuHandlerService
     }
     private static async Task EditItemInternal(string identifier, ItemEditContext context)
     {
-        var result = await Items.Update(identifier, context);
-        MainWindowViewModel.ShowNotification(
+        var result = await InstanceRepository.Items.Update(identifier, context);
+        NotificationManager.Show(
             result ? Localizer.Instance[Loc.Success.Default] : Localizer.Instance[Loc.Error.Default],
             result ? Localizer.Instance[Loc.Success.ItemEdit] : Localizer.Instance[Loc.Error.ItemEditFailed],
             result ? NotificationType.Success : NotificationType.Error
@@ -104,10 +96,10 @@ public static class ContextMenuHandlerService
 
     private static async void OpenFolder(string path)
     {
-        var result = await LauncherService.OpenFolder(TopLevelProvider.Current, path);
+        var result = await LauncherService.OpenFolder(path);
         if (result.IsError)
         {
-            MainWindowViewModel.ShowNotification(
+            NotificationManager.Show(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.OpenFolderFailed],
                 NotificationType.Error
@@ -116,39 +108,39 @@ public static class ContextMenuHandlerService
     }
     private static async void RemoveFolder(string path)
     {
-        var currentItem = ItemNavigationService.GetCurrentItemId();
+        var currentItem = InstanceRepository.NavigationService.GetCurrentItemId();
         var item = GetByIdentifier(currentItem ?? string.Empty);
         if (item == null) return;
 
         var isAppManaged = ItemUtils.IsAppManagedPath(item.ItemPath, path);
         if (isAppManaged)
         {
-            var removeFromDatabase = await MainWindowViewModel.Instance.ShowYesNoDialog(
+            var removeFromDatabase = await InstanceRepository.MainWindow.ShowYesNoDialog(
                 Localizer.Instance[Loc.Dialog.Confirmation.Default],
                 Localizer.Instance.Get(Localizer.Instance[Loc.Dialog.Confirmation.RemoveFolderFromApplicationManagedFolder], path)
             );
             if (!removeFromDatabase) return;
             
-            await Items.RemovePath(item.Identifier, path, true);
+            await InstanceRepository.Items.RemovePath(item.Identifier, path, true);
         }
         else if (item.ItemPaths.Contains(path))
         {
-            var removeFromDatabase = await MainWindowViewModel.Instance.ShowYesNoDialog(
+            var removeFromDatabase = await InstanceRepository.MainWindow.ShowYesNoDialog(
                 Localizer.Instance[Loc.Dialog.Confirmation.Default],
                 Localizer.Instance.Get(Loc.Dialog.Confirmation.RemoveFolderFromDatabase, path)
             );
             if (!removeFromDatabase) return;
 
-            var removeFolder = await MainWindowViewModel.Instance.ShowYesNoDialog(
+            var removeFolder = await InstanceRepository.MainWindow.ShowYesNoDialog(
                 Localizer.Instance[Loc.Dialog.Confirmation.Default],
                 Localizer.Instance.Get(Loc.Dialog.Confirmation.RemoveFolder, path)
             );
 
-            await Items.RemovePath(item.Identifier, path, removeFolder);
+            await InstanceRepository.Items.RemovePath(item.Identifier, path, removeFolder);
         }
         else
         {
-            MainWindowViewModel.ShowNotification(
+            NotificationManager.Show(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.ItemPathNotFound],
                 NotificationType.Error
@@ -156,7 +148,7 @@ public static class ContextMenuHandlerService
             return;
         }
         
-        MainWindowViewModel.ShowNotification(
+        NotificationManager.Show(
             Localizer.Instance[Loc.Success.Default],
             Localizer.Instance[Loc.Success.RemoveFolder],
             NotificationType.Success
@@ -167,10 +159,10 @@ public static class ContextMenuHandlerService
         var item = GetByIdentifier(identifier);
         if (item == null) return;
 
-        var updates = await AvatarExplorerApp.Instance.VariationHashes.CheckVariationAndNotify(item.BoothId.ToString());
+        var updates = await InstanceRepository.VariationHashes.CheckVariationAndNotify(item.BoothId.ToString());
         if (updates.Count == 0)
         {
-            MainWindowViewModel.ShowNotification(
+            NotificationManager.Show(
                 Localizer.Instance[Loc.VariationUpdate.NoUpdatesAvailable],
                 string.Empty,
                 NotificationType.Information
@@ -194,7 +186,7 @@ public static class ContextMenuHandlerService
             return $"- {variationName}\n{string.Join("\n", parts)}";
         });
 
-        MainWindowViewModel.ShowNotification(
+        NotificationManager.Show(
             Localizer.Instance[Loc.VariationUpdate.UpdateAvailable],
             string.Join("\n", contentLines),
             NotificationType.Information
@@ -207,7 +199,7 @@ public static class ContextMenuHandlerService
         if (string.IsNullOrEmpty(link)) return;
 
         var result = await ClipboardService.SetText(link);
-        MainWindowViewModel.ShowNotification(
+        NotificationManager.Show(
             !result.IsError ? Localizer.Instance[Loc.Success.Default] : Localizer.Instance[Loc.Error.Default],
             !result.IsError ? Localizer.Instance[Loc.Success.ClipboardSet] : Localizer.Instance[Loc.Error.ClipboardSetFailed],
             !result.IsError ? NotificationType.Success : NotificationType.Error
@@ -218,10 +210,10 @@ public static class ContextMenuHandlerService
         var link = GetByIdentifier(identifier)?.GetBoothLink(Localizer.Instance[Loc.BoothLanguageCode]);
         if (string.IsNullOrEmpty(link)) return;
 
-        var result = await LauncherService.OpenUri(TopLevelProvider.Current, link);
+        var result = await LauncherService.OpenUri(link);
         if (result.IsError)
         {
-            MainWindowViewModel.ShowNotification(
+            NotificationManager.Show(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.OpenUriFailed],
                 NotificationType.Error
@@ -233,16 +225,16 @@ public static class ContextMenuHandlerService
         var author = GetByIdentifier(identifier)?.Author;
         if (string.IsNullOrEmpty(author)) return;
 
-        var mainVm = MainWindowViewModel.Instance.MainVM;
+        var mainVm = InstanceRepository.MainWindow.MainVM;
         mainVm.SearchText = $"Author=\"{author}\"";
     }
     private static async void ChangeThumbnail(string identifier)
     {
-        var files = await StorageService.OpenFileDialog(TopLevelProvider.Current, "Select Thumbnail Image");
+        var files = await StorageService.OpenFileDialog(Localizer.Instance[Loc.Dialog.SelectFilePath]);
         if (files == null || files.Length == 0) return;
 
-        var result = await Items.UpdateThumbnail(identifier, files[0]);
-        MainWindowViewModel.ShowNotification(
+        var result = await InstanceRepository.Items.UpdateThumbnail(identifier, files[0]);
+        NotificationManager.Show(
             !result.IsError ? Localizer.Instance[Loc.Success.Default] : Localizer.Instance[Loc.Error.Default],
             !result.IsError ? Localizer.Instance[Loc.Success.ItemThumbnailEdit] : Localizer.Instance[Loc.Error.ItemThumbnailEditFailed],
             !result.IsError ? NotificationType.Success : NotificationType.Error
@@ -250,8 +242,8 @@ public static class ContextMenuHandlerService
     }
     private static async void FetchThumbnail(string identifier)
     {
-        var result = await Items.FetchThumbnailFromBooth(identifier);
-        MainWindowViewModel.ShowNotification(
+        var result = await InstanceRepository.Items.FetchThumbnailFromBooth(identifier);
+        NotificationManager.Show(
             !result.IsError ? Localizer.Instance[Loc.Success.Default] : Localizer.Instance[Loc.Error.Default],
             !result.IsError ? Localizer.Instance[Loc.Success.FetchItemThumbnail] : Localizer.Instance[Loc.Error.FetchItemThumbnailFailed],
             !result.IsError ? NotificationType.Success : NotificationType.Error
@@ -264,22 +256,19 @@ public static class ContextMenuHandlerService
 
         string itemInfo = string.Format("{0} - {1}\n{2}", item.Title, item.Author, item.BoothId != -1 ? item.GetBoothLink(Localizer.Instance[Loc.BoothLanguageCode]) : "(No Booth Link)");
         var result = await ClipboardService.SetText(itemInfo);
-        MainWindowViewModel.ShowNotification(
+        NotificationManager.Show(
             !result.IsError ? Localizer.Instance[Loc.Success.Default] : Localizer.Instance[Loc.Error.Default],
             !result.IsError ? Localizer.Instance[Loc.Success.ClipboardSet] : Localizer.Instance[Loc.Error.ClipboardSetFailed],
             !result.IsError ? NotificationType.Success : NotificationType.Error
         );
     }
-    private static void EditItem(string identifier)
-    {
-        MainWindowViewModel.Instance.ShowItemEditor(identifier);
-    }
+    private static void EditItem(string identifier) => InstanceRepository.MainWindow.ItemEditorVM.Open(identifier);
     private static async void EditItemTitle(string identifier)
     {
         var item = GetByIdentifier(identifier);
         if (item == null) return;
 
-        var newTitle = await MainWindowViewModel.Instance.ShowTextDialog(
+        var newTitle = await InstanceRepository.MainWindow.ShowTextDialog(
             Localizer.Instance[Loc.Dialog.Title.NewItemTitle],
             item.Title
         );
@@ -292,20 +281,19 @@ public static class ContextMenuHandlerService
         var item = GetByIdentifier(identifier);
         if (item == null) return;
 
-        var newMemo = await MainWindowViewModel.Instance.ShowEditMemoDialog(item.ItemMemo);
+        var newMemo = await InstanceRepository.MainWindow.ShowEditMemoDialog(item.ItemMemo);
         if (newMemo == null) return;
 
         await EditItemInternal(identifier, new() { ItemMemo = newMemo });
     }
     private static void AddToBulkImportList(string identifier)
     {
-        var bulkVm = MainWindowViewModel.Instance.MainVM.BulkImportVM;
+        var bulkVm = InstanceRepository.MainWindow.MainVM.BulkImportVM;
         bulkVm.AddItem(identifier);
     }
     private static async void AddItemFile(string identifier)
     {
         var files = await StorageService.OpenFileDialog(
-            TopLevelProvider.Current,
             Localizer.Instance[Loc.Dialog.SelectFilePath],
             allowMultiple: true
         );
@@ -320,7 +308,6 @@ public static class ContextMenuHandlerService
     private static async void AddItemFolder(string identifier)
     {
         var folders = await StorageService.OpenFolderDialog(
-            TopLevelProvider.Current,
             Localizer.Instance[Loc.Dialog.SelectFolderPath],
             allowMultiple: true
         );
@@ -334,11 +321,11 @@ public static class ContextMenuHandlerService
     }
     private static async Task AddPathsInternal(string identifier, IEnumerable<ItemPathEntry> paths, bool isFile)
     {
-        var extractResult = await Items.AddPaths(identifier, paths, RuntimeSettings.ShouldLinkToOriginal);
+        var extractResult = await InstanceRepository.Items.AddPaths(identifier, paths, InstanceRepository.RuntimeSettings.Settings.ShouldLinkToOriginal);
 
         if (extractResult.IsError)
         {
-            MainWindowViewModel.ShowNotification(
+            NotificationManager.Show(
                 Localizer.Instance[Loc.Error.Default],
                 isFile ? Localizer.Instance[Loc.Error.AddItemFileFailed] : Localizer.Instance[Loc.Error.AddItemFolderFailed],
                 NotificationType.Error
@@ -346,7 +333,7 @@ public static class ContextMenuHandlerService
         }
         else if (extractResult.Value.ProcessingFailedPaths.Count > 0)
         {
-            MainWindowViewModel.ShowNotification(
+            NotificationManager.Show(
                 Localizer.Instance[Loc.Warning.Default],
                 Localizer.Instance.Get(
                     Loc.Error.FoundProcessingFailedPath,
@@ -357,7 +344,7 @@ public static class ContextMenuHandlerService
         }
         else
         {
-            MainWindowViewModel.ShowNotification(
+            NotificationManager.Show(
                 Localizer.Instance[Loc.Success.Default],
                 isFile ? Localizer.Instance[Loc.Success.ItemFileAdd] : Localizer.Instance[Loc.Success.ItemFolderAdd],
                 NotificationType.Success
@@ -369,7 +356,7 @@ public static class ContextMenuHandlerService
         var item = GetByIdentifier(identifier);
         if (item == null) return;
 
-        var newAvatars = await MainWindowViewModel.Instance.ShowSelectAvatars(
+        var newAvatars = await InstanceRepository.MainWindow.ShowSelectAvatars(
             Localizer.Instance[Loc.SelectAvatars.Title.ImplementedAvatars],
             item.ImplementedAvatars.ToArray(),
             includeCommonAvatar: false,
@@ -386,14 +373,13 @@ public static class ContextMenuHandlerService
         if (item == null) return;
 
         var folders = await StorageService.OpenFolderDialog(
-            TopLevelProvider.Current,
             Localizer.Instance[Loc.Dialog.SelectFolderPath],
             allowMultiple: false
         );
         if (folders == null || folders.Length == 0) return;
 
-        var result = await Items.Update(item.Identifier, new() { ItemPath = folders[0] });
-        MainWindowViewModel.ShowNotification(
+        var result = await InstanceRepository.Items.Update(item.Identifier, new() { ItemPath = folders[0] });
+        NotificationManager.Show(
             result ? Localizer.Instance[Loc.Success.Default] : Localizer.Instance[Loc.Error.Default],
             result ? Localizer.Instance[Loc.Success.ItemEdit] : Localizer.Instance[Loc.Error.ItemEditFailed],
             result ? NotificationType.Success : NotificationType.Error
@@ -404,7 +390,7 @@ public static class ContextMenuHandlerService
         var item = GetByIdentifier(identifier);
         if (item == null) return;
 
-        var newTags = await MainWindowViewModel.Instance.ShowEditTagsDialog(item.Tags.ToArray());
+        var newTags = await InstanceRepository.MainWindow.ShowEditTagsDialog(item.Tags.ToArray());
         if (newTags == null) return;
 
         await EditItemInternal(item.Identifier, new() { Tags = newTags });
@@ -414,7 +400,7 @@ public static class ContextMenuHandlerService
         var item = GetByIdentifier(identifier);
         if (item == null) return;
 
-        var removeResult = await MainWindowViewModel.Instance.ShowYesNoDialog(
+        var removeResult = await InstanceRepository.MainWindow.ShowYesNoDialog(
             Localizer.Instance[Loc.Dialog.Confirmation.Default],
             Localizer.Instance.Get(Loc.Dialog.Confirmation.RemoveItem, item.Title)
         );
@@ -424,15 +410,15 @@ public static class ContextMenuHandlerService
 
         if (!string.IsNullOrEmpty(item.ItemPath) && Directory.Exists(item.ItemPath))
         {
-            removeDirectory = await MainWindowViewModel.Instance.ShowYesNoDialog(
+            removeDirectory = await InstanceRepository.MainWindow.ShowYesNoDialog(
                 Localizer.Instance[Loc.Dialog.Confirmation.Default],
                 Localizer.Instance.Get(Loc.Dialog.Confirmation.RemoveAssetData, item.ItemPath)
             );
         }
 
-        ItemGroupService.RemoveItem(item.Identifier, removeDirectory);
+        InstanceRepository.ItemGroupService.RemoveItem(item.Identifier, removeDirectory);
 
-        MainWindowViewModel.ShowNotification(
+        NotificationManager.Show(
             Localizer.Instance[Loc.Success.Default],
             Localizer.Instance[Loc.Success.Remove],
             NotificationType.Success
@@ -440,10 +426,10 @@ public static class ContextMenuHandlerService
     }
     private static async void OpenFile(string path)
     {
-        var result = await LauncherService.OpenFile(TopLevelProvider.Current, path);
+        var result = await LauncherService.OpenFile(path);
         if (result.IsError)
         {
-            MainWindowViewModel.ShowNotification(
+            NotificationManager.Show(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.OpenFileFailed],
                 NotificationType.Error
@@ -452,10 +438,10 @@ public static class ContextMenuHandlerService
     }
     private static void AddFileToBulkImportList(string path)
     {
-        var currentItem = ItemNavigationService.GetCurrentItemId();
+        var currentItem = InstanceRepository.NavigationService.GetCurrentItemId();
         if (string.IsNullOrEmpty(currentItem)) return;
         
-        var bulkVm = MainWindowViewModel.Instance.MainVM.BulkImportVM;
+        var bulkVm = InstanceRepository.MainWindow.MainVM.BulkImportVM;
         bulkVm.AddItem(currentItem, path);
     }
     private static void ShowInExplorer(string path)
@@ -468,7 +454,7 @@ public static class ContextMenuHandlerService
         }
         catch (Exception ex)
         {
-            MainWindowViewModel.ShowNotification(
+            NotificationManager.Show(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.OpenFileFailed],
                 NotificationType.Error
@@ -478,18 +464,18 @@ public static class ContextMenuHandlerService
     }
     private static void OpenUnitypackageViewer(string path)
     {
-        MainWindowViewModel.Instance.ShowUnitypackageViewer(path);
+        InstanceRepository.MainWindow.UnitypackageViewerVM.Open(path);
     }
     private static void OpenPdfViewer(string path)
     {
-        MainWindowViewModel.Instance.ShowPdfViewer(path);
+        InstanceRepository.MainWindow.PdfViewerVM.Open(path);
     }
     private static async void RemovePreset(string identifier)
     {
-        var preset = AvatarExplorerApp.Instance.BulkImportPresets.Get(identifier);
+        var preset = InstanceRepository.BulkImportPresets.Get(identifier);
         if (preset == null)
         {
-            MainWindowViewModel.ShowNotification(
+            NotificationManager.Show(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.PresetNotFound],
                 NotificationType.Error
@@ -497,15 +483,15 @@ public static class ContextMenuHandlerService
             return;
         }
 
-        var result = await MainWindowViewModel.Instance.ShowYesNoDialog(
+        var result = await InstanceRepository.MainWindow.ShowYesNoDialog(
             Localizer.Instance[Loc.Dialog.Confirmation.Default],
             Localizer.Instance.Get(Loc.Dialog.Confirmation.RemovePreset, preset.PresetName)
         );
         if (!result) return;
 
-        AvatarExplorerApp.Instance.BulkImportPresets.Remove(preset.Identifier);
+        InstanceRepository.BulkImportPresets.Remove(preset.Identifier);
 
-        MainWindowViewModel.ShowNotification(
+        NotificationManager.Show(
             Localizer.Instance[Loc.Success.Default],
             Localizer.Instance[Loc.Success.Remove],
             NotificationType.Success
@@ -513,10 +499,10 @@ public static class ContextMenuHandlerService
     }
     private static async void EditTempAvatarName(string identifier)
     {
-        var tempAvatar = AvatarExplorerApp.Instance.TempAvatars.Get(identifier);
+        var tempAvatar = InstanceRepository.TempAvatars.Get(identifier);
         if (tempAvatar == null)
         {
-            MainWindowViewModel.ShowNotification(
+            NotificationManager.Show(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.TempAvatarNotFound],
                 NotificationType.Error
@@ -524,15 +510,15 @@ public static class ContextMenuHandlerService
             return;
         }
 
-        var newName = await MainWindowViewModel.Instance.ShowTextDialog(
+        var newName = await InstanceRepository.MainWindow.ShowTextDialog(
             Localizer.Instance[Loc.Dialog.Title.NewTempAvatarName],
             tempAvatar.AvatarName
         );
         if (string.IsNullOrEmpty(newName)) return;
 
-        AvatarExplorerApp.Instance.TempAvatars.RenameAvatar(tempAvatar.Identifier, newName);
+        InstanceRepository.TempAvatars.RenameAvatar(tempAvatar.Identifier, newName);
 
-        MainWindowViewModel.ShowNotification(
+        NotificationManager.Show(
             Localizer.Instance[Loc.Success.Default],
             Localizer.Instance[Loc.Success.ItemEdit],
             NotificationType.Success
@@ -540,14 +526,14 @@ public static class ContextMenuHandlerService
     }
     private static void ResolveTempAvatar(string identifier)
     {
-        MainWindowViewModel.Instance.ShowTempAvatarResolver(identifier);
+        InstanceRepository.MainWindow.ResolveTempAvatarVM.Open(identifier);
     }
     private static async void RemoveTempAvatar(string identifier)
     {
-        var tempAvatar = AvatarExplorerApp.Instance.TempAvatars.Get(identifier);
+        var tempAvatar = InstanceRepository.TempAvatars.Get(identifier);
         if (tempAvatar == null)
         {
-            MainWindowViewModel.ShowNotification(
+            NotificationManager.Show(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.TempAvatarNotFound],
                 NotificationType.Error
@@ -555,15 +541,15 @@ public static class ContextMenuHandlerService
             return;
         }
 
-        var result = await MainWindowViewModel.Instance.ShowYesNoDialog(
+        var result = await InstanceRepository.MainWindow.ShowYesNoDialog(
             Localizer.Instance[Loc.Dialog.Confirmation.Default],
             Localizer.Instance.Get(Loc.Dialog.Confirmation.RemoveTempAvatar, tempAvatar.AvatarName)
         );
         if (!result) return;
 
-        ItemGroupService.RemoveTempAvatar(tempAvatar.Identifier);
+        InstanceRepository.ItemGroupService.RemoveTempAvatar(tempAvatar.Identifier);
 
-        MainWindowViewModel.ShowNotification(
+        NotificationManager.Show(
             Localizer.Instance[Loc.Success.Default],
             Localizer.Instance[Loc.Success.Remove],
             NotificationType.Success
@@ -573,27 +559,27 @@ public static class ContextMenuHandlerService
     {
         var oldCategory = ItemCategory.FromIdentifier(identifier).CustomCategory;
 
-        var newName = await MainWindowViewModel.Instance.ShowTextDialog(
+        var newName = await InstanceRepository.MainWindow.ShowTextDialog(
             Localizer.Instance[Loc.Dialog.Title.NewCustomCategoryName],
             oldCategory
         );
         if (string.IsNullOrEmpty(newName)) return;
 
-        var isDuplicate = AvatarExplorerApp.Instance.Items.GetAll()
+        var isDuplicate = InstanceRepository.Items.GetAll()
             .Any(i => i.Category.Type == ItemType.Custom && i.Category.CustomCategory == newName);
 
         if (isDuplicate)
         {
-            var result = await MainWindowViewModel.Instance.ShowYesNoDialog(
+            var result = await InstanceRepository.MainWindow.ShowYesNoDialog(
                 Localizer.Instance[Loc.Dialog.Confirmation.Default],
                 Localizer.Instance[Loc.Dialog.Confirmation.DuplicateCustomCategoryName]
             );
             if (!result) return;
         }
 
-        AvatarExplorerApp.Instance.Items.RenameCustomCategory(oldCategory, newName);
+        InstanceRepository.Items.RenameCustomCategory(oldCategory, newName);
 
-        MainWindowViewModel.ShowNotification(
+        NotificationManager.Show(
             Localizer.Instance[Loc.Success.Default],
             Localizer.Instance[Loc.Success.RenameCustomCategory],
             NotificationType.Success
@@ -601,6 +587,6 @@ public static class ContextMenuHandlerService
     }
     private static void MergeWithOtherCategory(string identifier)
     {
-        MainWindowViewModel.Instance.MergeCategoryVM.Open(identifier);
+        InstanceRepository.MainWindow.MergeCategoryVM.Open(identifier);
     }
 }

--- a/AvatarExplorer.UI/Services/ContextMenu/ContextMenuHandlerService.cs
+++ b/AvatarExplorer.UI/Services/ContextMenu/ContextMenuHandlerService.cs
@@ -14,7 +14,6 @@ using AvatarExplorer.UI.Localization;
 using AvatarExplorer.UI.Models.ContextMenu;
 using AvatarExplorer.UI.Services.System;
 using AvatarExplorer.UI.Services.Utilities;
-using AvatarExplorer.UI.ViewModels;
 
 namespace AvatarExplorer.UI.Services.ContextMenu;
 

--- a/AvatarExplorer.UI/Services/ContextMenu/ContextMenuHandlerService.cs
+++ b/AvatarExplorer.UI/Services/ContextMenu/ContextMenuHandlerService.cs
@@ -321,7 +321,7 @@ public static class ContextMenuHandlerService
     }
     private static async Task AddPathsInternal(string identifier, IEnumerable<ItemPathEntry> paths, bool isFile)
     {
-        var extractResult = await InstanceRepository.Items.AddPaths(identifier, paths, InstanceRepository.RuntimeSettings.Settings.ShouldLinkToOriginal);
+        var extractResult = await InstanceRepository.Items.AddPaths(identifier, paths, InstanceRepository.RuntimeSettings.ShouldLinkToOriginal);
 
         if (extractResult.IsError)
         {

--- a/AvatarExplorer.UI/Services/InstanceRepository.cs
+++ b/AvatarExplorer.UI/Services/InstanceRepository.cs
@@ -1,6 +1,8 @@
+using AvatarExplorer.Core.Models.System;
 using AvatarExplorer.Core.Services.Items;
 using AvatarExplorer.Core.Services.System;
 using AvatarExplorer.Core.Services.System.Repositories;
+using AvatarExplorer.UI.Models.Settings;
 using AvatarExplorer.UI.Services.System;
 using AvatarExplorer.UI.ViewModels;
 
@@ -18,11 +20,13 @@ public static class InstanceRepository
     public static ItemGroupService ItemGroupService => App.ItemGroupService;
 
     public static ItemNavigationService NavigationService => App.ItemNavigationService;
-    public static RuntimeSettingsRepository RuntimeSettings => App.RuntimeSettingsRepository;
+    public static RuntimeSettingsRepository RuntimeSettingsRepository => App.RuntimeSettingsRepository;
+    public static RuntimeSettings RuntimeSettings => App.RuntimeSettings;
     public static BackupManager BackupManager => App.BackupManager;
 
     // UI
     public static MainWindowViewModel MainWindow => MainWindowViewModel.Instance;
     public static MainViewModel MainView => MainWindow.MainVM;
-    public static UserPreferencesRepository UserPreferences => UserPreferencesService.Instance.Repository;
+    public static UserPreferencesRepository UserPreferencesRepository => UserPreferencesService.Instance.Repository;
+    public static UserPreferences UserPreferences => UserPreferencesRepository.Settings;
 }

--- a/AvatarExplorer.UI/Services/InstanceRepository.cs
+++ b/AvatarExplorer.UI/Services/InstanceRepository.cs
@@ -1,0 +1,28 @@
+using AvatarExplorer.Core.Services.Items;
+using AvatarExplorer.Core.Services.System;
+using AvatarExplorer.Core.Services.System.Repositories;
+using AvatarExplorer.UI.Services.System;
+using AvatarExplorer.UI.ViewModels;
+
+namespace AvatarExplorer.UI.Services;
+
+public static class InstanceRepository
+{
+    // Core
+    public static AvatarExplorerApp App => AvatarExplorerApp.Instance;
+    public static ItemRepository Items => App.ItemRepository;
+    public static CommonAvatarRepository CommonAvatars => App.CommonAvatarRepository;
+    public static TempAvatarRepository TempAvatars => App.TempAvatarRepository;
+    public static BulkImportPresetRepository BulkImportPresets => App.BulkImportPresetRepository;
+    public static VariationHashRepository VariationHashes => App.VariationHashRepository;
+    public static ItemGroupService ItemGroupService => App.ItemGroupService;
+
+    public static ItemNavigationService NavigationService => App.ItemNavigationService;
+    public static RuntimeSettingsRepository RuntimeSettings => App.RuntimeSettingsRepository;
+    public static BackupManager BackupManager => App.BackupManager;
+
+    // UI
+    public static MainWindowViewModel MainWindow => MainWindowViewModel.Instance;
+    public static MainViewModel MainView => MainWindow.MainVM;
+    public static UserPreferencesRepository UserPreferences => UserPreferencesService.Instance.Repository;
+}

--- a/AvatarExplorer.UI/Services/System/NotificationManager.cs
+++ b/AvatarExplorer.UI/Services/System/NotificationManager.cs
@@ -1,0 +1,35 @@
+using System;
+using Avalonia.Controls.Notifications;
+using Message.Avalonia;
+using Message.Avalonia.Models;
+
+namespace AvatarExplorer.UI.Services.System;
+
+public static class NotificationManager
+{
+    public static void Show(string title, string content, NotificationType type)
+    {
+        var manager = MessageManager.Default;
+        var messageOptions = new MessageOptions
+        {
+            Title = title,
+            Duration = TimeSpan.FromSeconds(3.5)
+        };
+
+        switch (type)
+        {
+            case NotificationType.Information:
+                manager.ShowInformationMessage(content, messageOptions);
+                break;
+            case NotificationType.Success:
+                manager.ShowSuccessMessage(content, messageOptions);
+                break;
+            case NotificationType.Warning:
+                manager.ShowWarningMessage(content, messageOptions);
+                break;
+            case NotificationType.Error:
+                manager.ShowErrorMessage(content, messageOptions);
+                break;
+        }
+    }
+}

--- a/AvatarExplorer.UI/Services/Utilities/LauncherService.cs
+++ b/AvatarExplorer.UI/Services/Utilities/LauncherService.cs
@@ -1,10 +1,10 @@
 using System;
 using System.IO;
 using System.Threading.Tasks;
-using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Platform.Storage;
 using AvatarExplorer.Core.Services.System;
+using AvatarExplorer.UI.Services.System;
 using ErrorOr;
 
 namespace AvatarExplorer.UI.Services.Utilities;
@@ -13,11 +13,11 @@ internal static class LauncherService
 {
     private static ILauncher? GetLauncher(TopLevel? topLevel) => topLevel?.Launcher;
 
-    internal static async Task<ErrorOr<Success>> OpenFile(TopLevel? topLevel, string filePath)
+    internal static async Task<ErrorOr<Success>> OpenFile(string filePath)
     {
         try
         {
-            var launcher = GetLauncher(topLevel);
+            var launcher = GetLauncher(TopLevelProvider.Current);
             if (launcher == null) return Error.Failure(description: "Failed to get launcher.");
 
             var fileInfo = new FileInfo(filePath);
@@ -32,11 +32,11 @@ internal static class LauncherService
         }
     }
 
-    internal static async Task<ErrorOr<Success>> OpenFolder(TopLevel? topLevel, string folderPath)
+    internal static async Task<ErrorOr<Success>> OpenFolder(string folderPath)
     {
         try
         {
-            var launcher = GetLauncher(topLevel);
+            var launcher = GetLauncher(TopLevelProvider.Current);
             if (launcher == null) return Error.Failure(description: "Failed to get launcher.");
 
             var folderInfo = new DirectoryInfo(folderPath);
@@ -51,11 +51,11 @@ internal static class LauncherService
         }
     }
 
-    internal static async Task<ErrorOr<Success>> OpenUri(TopLevel? topLevel, string uri)
+    internal static async Task<ErrorOr<Success>> OpenUri(string uri)
     {
         try
         {
-            var launcher = GetLauncher(topLevel);
+            var launcher = GetLauncher(TopLevelProvider.Current);
             if (launcher == null) return Error.Failure(description: "Failed to get launcher.");
 
             var uriInfo = new Uri(uri);

--- a/AvatarExplorer.UI/Services/Utilities/StorageService.cs
+++ b/AvatarExplorer.UI/Services/Utilities/StorageService.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Platform.Storage;
 using AvatarExplorer.Core.Services.System;
+using AvatarExplorer.UI.Services.System;
 
 namespace AvatarExplorer.UI.Services.Utilities;
 
@@ -12,11 +13,11 @@ internal static class StorageService
 {
     private static IStorageProvider? GetStorageProvider(TopLevel? topLebel) => topLebel?.StorageProvider;
 
-    internal static async Task<string[]?> OpenFileDialog(TopLevel? topLebel, string title, bool allowMultiple = false)
+    internal static async Task<string[]?> OpenFileDialog(string title, bool allowMultiple = false)
     {
         try
         {
-            var storageProvider = GetStorageProvider(topLebel);
+            var storageProvider = GetStorageProvider(TopLevelProvider.Current);
             if (storageProvider == null) return [];
 
             var files = await storageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
@@ -40,11 +41,11 @@ internal static class StorageService
         }
     }
 
-    internal static async Task<string[]?> OpenFolderDialog(TopLevel? topLebel, string title, bool allowMultiple = false, string? initialPath = null)
+    internal static async Task<string[]?> OpenFolderDialog(string title, bool allowMultiple = false, string? initialPath = null)
     {
         try
         {
-            var storageProvider = GetStorageProvider(topLebel);
+            var storageProvider = GetStorageProvider(TopLevelProvider.Current);
             if (storageProvider == null) return [];
 
             var folderPickerOpenOptions = new FolderPickerOpenOptions()
@@ -72,11 +73,11 @@ internal static class StorageService
         }
     }
 
-    internal static async Task<string?> OpenSaveFileDialog(TopLevel? topLebel, string title, string defaultExtension)
+    internal static async Task<string?> OpenSaveFileDialog(string title, string defaultExtension)
     {
         try
         {
-            var storageProvider = GetStorageProvider(topLebel);
+            var storageProvider = GetStorageProvider(TopLevelProvider.Current);
             if (storageProvider == null) return null;
 
             var file = await storageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
@@ -94,11 +95,11 @@ internal static class StorageService
         }
     }
 
-    internal static async Task<IStorageFile?> GetStorageFileFromPath(TopLevel? topLebel, string filePath)
+    internal static async Task<IStorageFile?> GetStorageFileFromPath(string filePath)
     {
         try
         {
-            var storageProvider = GetStorageProvider(topLebel);
+            var storageProvider = GetStorageProvider(TopLevelProvider.Current);
             if (storageProvider == null) return null;
 
             return await storageProvider.TryGetFileFromPathAsync(filePath);

--- a/AvatarExplorer.UI/Services/ViewControl/ContextMenuCreator.cs
+++ b/AvatarExplorer.UI/Services/ViewControl/ContextMenuCreator.cs
@@ -41,39 +41,39 @@ internal static class ContextMenuCreator
     {
         List<ContextMenuAction> contextMenuActions =
         [
-            new ContextMenuAction(Loc.ContextMenu.Item.CheckForUpdate, ActionKey.CheckForUpdate, ContextMenuIconType.Update, itemId, addSeparator: true),
-            new ContextMenuAction(Loc.ContextMenu.Item.ShowOtherItemsByAuthor, ActionKey.ShowOtherItemsByAuthor, ContextMenuIconType.Open, itemId, addSeparator: true),
+            new(Loc.ContextMenu.Item.CheckForUpdate, ActionKey.CheckForUpdate, ContextMenuIconType.Update, itemId, addSeparator: true),
+            new(Loc.ContextMenu.Item.ShowOtherItemsByAuthor, ActionKey.ShowOtherItemsByAuthor, ContextMenuIconType.Open, itemId, addSeparator: true),
 
-            new ContextMenuAction(Loc.ContextMenu.Item.Add.BulkImportList, ActionKey.AddToBulkImportList, ContextMenuIconType.Add, itemId),
-            new ContextMenuAction(Loc.ContextMenu.Item.Add.File, ActionKey.None, ContextMenuIconType.Add, addSeparator: true)
+            new(Loc.ContextMenu.Item.Add.BulkImportList, ActionKey.AddToBulkImportList, ContextMenuIconType.Add, itemId),
+            new(Loc.ContextMenu.Item.Add.File, ActionKey.None, ContextMenuIconType.Add, addSeparator: true)
             {
                 SubMenuItems =
                 {
-                    new ContextMenuAction(Loc.ContextMenu.Item.Add.File, ActionKey.AddItemFile, ContextMenuIconType.Add, itemId),
-                    new ContextMenuAction(Loc.ContextMenu.Item.Add.Folder, ActionKey.AddItemFolder, ContextMenuIconType.Add, itemId)
+                    new(Loc.ContextMenu.Item.Add.File, ActionKey.AddItemFile, ContextMenuIconType.Add, itemId),
+                    new(Loc.ContextMenu.Item.Add.Folder, ActionKey.AddItemFolder, ContextMenuIconType.Add, itemId)
                 }
             },
-            new ContextMenuAction(Loc.ContextMenu.Item.Booth.Open, ActionKey.OpenBoothLink, ContextMenuIconType.Open, itemId),
-            new ContextMenuAction(Loc.ContextMenu.Item.Booth.Copy, ActionKey.CopyBoothLink, ContextMenuIconType.Copy, itemId, addSeparator: true),
+            new(Loc.ContextMenu.Item.Booth.Open, ActionKey.OpenBoothLink, ContextMenuIconType.Open, itemId),
+            new(Loc.ContextMenu.Item.Booth.Copy, ActionKey.CopyBoothLink, ContextMenuIconType.Copy, itemId, addSeparator: true),
 
-            new ContextMenuAction(Loc.ContextMenu.Item.CopyItemInfo, ActionKey.CopyItemInfo, ContextMenuIconType.Copy, itemId, addSeparator: true),
+            new(Loc.ContextMenu.Item.CopyItemInfo, ActionKey.CopyItemInfo, ContextMenuIconType.Copy, itemId, addSeparator: true),
 
-            new ContextMenuAction(Loc.ContextMenu.Item.Edit.Tag, ActionKey.EditItemTag, ContextMenuIconType.Edit, itemId),
-            new ContextMenuAction(Loc.ContextMenu.Item.Edit.Memo, ActionKey.EditItemMemo, ContextMenuIconType.Edit, itemId),
-            new ContextMenuAction(Loc.ContextMenu.Item.Edit.Implemented, ActionKey.EditImplementedAvatar, ContextMenuIconType.Edit, itemId, addSeparator: true),
-            new ContextMenuAction(Loc.ContextMenu.Item.Edit.Default, ActionKey.None, ContextMenuIconType.Edit, itemId, addSeparator: true)
+            new(Loc.ContextMenu.Item.Edit.Tag, ActionKey.EditItemTag, ContextMenuIconType.Edit, itemId),
+            new(Loc.ContextMenu.Item.Edit.Memo, ActionKey.EditItemMemo, ContextMenuIconType.Edit, itemId),
+            new(Loc.ContextMenu.Item.Edit.Implemented, ActionKey.EditImplementedAvatar, ContextMenuIconType.Edit, itemId, addSeparator: true),
+            new(Loc.ContextMenu.Item.Edit.Default, ActionKey.None, ContextMenuIconType.Edit, itemId, addSeparator: true)
             {
                 SubMenuItems =
                 {
-                    new ContextMenuAction(Loc.ContextMenu.Item.Edit.Default, ActionKey.EditItem, ContextMenuIconType.Edit, itemId),
-                    new ContextMenuAction(Loc.ContextMenu.Item.Edit.Title, ActionKey.EditItemTitle, ContextMenuIconType.Edit, itemId),
-                    new ContextMenuAction(Loc.ContextMenu.Item.Edit.DefaultPath, ActionKey.EditItemDefaultPath, ContextMenuIconType.Edit, itemId, addSeparator: true),
-                    new ContextMenuAction(Loc.ContextMenu.Item.Thumbnail.Change, ActionKey.ChangeThumbnail, ContextMenuIconType.Edit, itemId),
-                    new ContextMenuAction(Loc.ContextMenu.Item.Thumbnail.Fetch, ActionKey.FetchThumbnail, ContextMenuIconType.Fetch, itemId)
+                    new(Loc.ContextMenu.Item.Edit.Default, ActionKey.EditItem, ContextMenuIconType.Edit, itemId),
+                    new(Loc.ContextMenu.Item.Edit.Title, ActionKey.EditItemTitle, ContextMenuIconType.Edit, itemId),
+                    new(Loc.ContextMenu.Item.Edit.DefaultPath, ActionKey.EditItemDefaultPath, ContextMenuIconType.Edit, itemId, addSeparator: true),
+                    new(Loc.ContextMenu.Item.Thumbnail.Change, ActionKey.ChangeThumbnail, ContextMenuIconType.Edit, itemId),
+                    new(Loc.ContextMenu.Item.Thumbnail.Fetch, ActionKey.FetchThumbnail, ContextMenuIconType.Fetch, itemId)
                 }
             },
 
-            new ContextMenuAction(Loc.ContextMenu.Item.Remove, ActionKey.RemoveItem, ContextMenuIconType.Delete, itemId)
+            new(Loc.ContextMenu.Item.Remove, ActionKey.RemoveItem, ContextMenuIconType.Delete, itemId)
         ];
 
         return contextMenuActions.ToArray();

--- a/AvatarExplorer.UI/ViewModels/MainViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/MainViewModel.cs
@@ -21,6 +21,7 @@ using AvatarExplorer.UI.Interfaces;
 using AvatarExplorer.UI.Localization;
 using AvatarExplorer.UI.Models.Settings;
 using AvatarExplorer.UI.Models.Sort;
+using AvatarExplorer.UI.Services;
 using AvatarExplorer.UI.Services.External;
 using AvatarExplorer.UI.Services.Sort;
 using AvatarExplorer.UI.Services.System;
@@ -37,7 +38,6 @@ namespace AvatarExplorer.UI.ViewModels;
 public class MainViewModel : ViewModelBase, IInitializable, IPostInitializable
 {
     #region Properties
-    public static MainViewModel Instance { get; private set; } = null!;
     public AdvancedSearchViewModel AdvancedSearchVM { get; } = new();
     public BulkImportViewModel BulkImportVM { get; } = new();
     public BulkImportPresetViewModel BulkImportPresetVM { get; } = new();
@@ -104,22 +104,20 @@ public class MainViewModel : ViewModelBase, IInitializable, IPostInitializable
     private readonly Guid _preLevel1StateGuid = Guid.NewGuid();
     private bool _isPreviousScreenSearch = false;
 
-    private static UserPreferences UserPreferences => UserPreferencesService.Instance.Repository.Settings;
+    private static UserPreferences UserPreferences => InstanceRepository.UserPreferences.Settings;
     #endregion
 
     #region Constructor
     public MainViewModel()
     {
-        Instance = this;
-
         UndoCommand = ReactiveCommand.Create(Undo);
         HomeCommand = ReactiveCommand.Create(GoHome);
-        OpenSettingsCommand = ReactiveCommand.Create(() => MainWindowViewModel.Instance.SettingsVM.Open());
-        AddItemCommand = ReactiveCommand.Create(() => MainWindowViewModel.Instance.ShowItemEditor());
+        OpenSettingsCommand = ReactiveCommand.Create(OpenSettings);
+        AddItemCommand = ReactiveCommand.Create(OpenItemEditor);
         SidePanelButtonPressedCommand = ReactiveCommand.Create<int>(SidePanelButtonPressed);
         SelectLeftItemCommand = ReactiveCommand.Create<ItemViewModel>(OnLeftItemSelected);
         SelectRightItemCommand = ReactiveCommand.Create<ItemViewModel>(OnRightItemSelected);
-        OpenSidePanelCommand = ReactiveCommand.Create<string>(OpenSidePanel);
+        OpenSidePanelCommand = ReactiveCommand.Create<string>(i => OpenSidePanel(ValueParser.Int(i)));
         NavigateToSegmentCommand = ReactiveCommand.Create<string>(NavigateToSegment);
 
         LeftGoFirstCommand = ReactiveCommand.Create(LeftPageInfo.GoFirst);
@@ -131,8 +129,8 @@ public class MainViewModel : ViewModelBase, IInitializable, IPostInitializable
         RightGoNextCommand = ReactiveCommand.Create(RightPageInfo.GoNext);
         RightGoLastCommand = ReactiveCommand.Create(RightPageInfo.GoLast);
 
-        _itemGroupService = AvatarExplorerApp.Instance.ItemGroupService;
-        _itemNavigationService = AvatarExplorerApp.Instance.ItemNavigationService;
+        _itemGroupService = InstanceRepository.ItemGroupService;
+        _itemNavigationService = InstanceRepository.NavigationService;
 
         _hoverThumbnailManager = new HoverThumbnailManager(this);
         _sidePanelManager = new SidePanelManager(this);
@@ -153,14 +151,14 @@ public class MainViewModel : ViewModelBase, IInitializable, IPostInitializable
         InitializeSubscriptions();
 
         Localizer.Instance.LanguageChanged += RefreshAllItems;
-        UserPreferencesService.Instance.Repository.OnSettingsChanged += _ =>
+        InstanceRepository.UserPreferences.OnSettingsChanged += _ =>
         {
             UpdateItemsPerPage();
             Refresh();
         };
         _itemNavigationService.FileOpenRequested += OnFileOpenRequested;
         AdvancedSearchVM.SearchPropertyChanged += _searchManager.RestartTimer;
-        BulkImportVM.OnItemsChanged += () => OpenSidePanel("1");
+        BulkImportVM.OnItemsChanged += () => OpenSidePanel(1);
     }
 
     public async Task OnInitialized()
@@ -208,7 +206,7 @@ public class MainViewModel : ViewModelBase, IInitializable, IPostInitializable
             var itemId = _itemNavigationService.GetCurrentItemId();
             if (itemId == null)
             {
-                MainWindowViewModel.ShowNotification(
+                NotificationManager.Show(
                     Localizer.Instance[Loc.Error.Default],
                     Localizer.Instance[Loc.Error.FailedToGetCurrentItem],
                     NotificationType.Error
@@ -219,7 +217,7 @@ public class MainViewModel : ViewModelBase, IInitializable, IPostInitializable
             var item = _itemGroupService.ItemRepository.Get(itemId);
             if (item == null)
             {
-                MainWindowViewModel.ShowNotification(
+                NotificationManager.Show(
                     Localizer.Instance[Loc.Error.Default],
                     Localizer.Instance[Loc.Error.ItemNotFound],
                     NotificationType.Error
@@ -231,22 +229,22 @@ public class MainViewModel : ViewModelBase, IInitializable, IPostInitializable
             var isLocalizable = category.IsLocalizable;
             var displayName = isLocalizable ? Localizer.Instance[item.Category.ToString()] : item.Category.ToString();
 
-            MainWindowViewModel.Instance.ProgressVM.Open(Localizer.Instance[Loc.Processing.Unitypackage.Status.Preparing]);
+            InstanceRepository.MainWindow.ProgressVM.Open(Localizer.Instance[Loc.Processing.Unitypackage.Status.Preparing]);
             var importResult = await UnitypackageService.Import(
                 [ new() { FilePath = file, CategoryDisplayName = displayName } ],
                 onProgress: async (name, percent) =>
                 {
-                    MainWindowViewModel.Instance.ProgressVM.Update(
+                    InstanceRepository.MainWindow.ProgressVM.Update(
                         Localizer.Instance.Get(name, percent.ToString()),
                         percent
                     );
                 }
             );
-            MainWindowViewModel.Instance.ProgressVM.Close();
+            InstanceRepository.MainWindow.ProgressVM.Close();
 
             if (importResult.ContainsScripts)
             {
-                MainWindowViewModel.ShowNotification(
+                NotificationManager.Show(
                     Localizer.Instance[Loc.Warning.Default],
                     Localizer.Instance[Loc.Warning.ScriptsFoundInUnitypackage],
                     NotificationType.Warning
@@ -255,10 +253,10 @@ public class MainViewModel : ViewModelBase, IInitializable, IPostInitializable
 
             if (!importResult.IsError && !string.IsNullOrEmpty(importResult.ModifiedUnitypackagePath))
             {
-                var result = await LauncherService.OpenFile(TopLevelProvider.Current, importResult.ModifiedUnitypackagePath);
+                var result = await LauncherService.OpenFile(importResult.ModifiedUnitypackagePath);
                 if (result.IsError)
                 {
-                    MainWindowViewModel.ShowNotification(
+                    NotificationManager.Show(
                         Localizer.Instance[Loc.Error.Default],
                         Localizer.Instance[Loc.Error.OpenFileFailed],
                         NotificationType.Error
@@ -267,7 +265,7 @@ public class MainViewModel : ViewModelBase, IInitializable, IPostInitializable
             }
             else
             {
-                MainWindowViewModel.ShowNotification(
+                NotificationManager.Show(
                     Localizer.Instance[Loc.Error.Default],
                     Localizer.Instance[Loc.Error.ImportUnitypackageFailed],
                     NotificationType.Error
@@ -276,10 +274,10 @@ public class MainViewModel : ViewModelBase, IInitializable, IPostInitializable
         }
         else
         {
-            var result = await LauncherService.OpenFile(TopLevelProvider.Current, file);
+            var result = await LauncherService.OpenFile(file);
             if (result.IsError)
             {
-                MainWindowViewModel.ShowNotification(
+                NotificationManager.Show(
                     Localizer.Instance[Loc.Error.Default],
                     Localizer.Instance[Loc.Error.OpenFileFailed],
                     NotificationType.Error
@@ -287,10 +285,7 @@ public class MainViewModel : ViewModelBase, IInitializable, IPostInitializable
             }
         }
     }
-    public void OpenSidePanel(string index)
-    {
-        _sidePanelManager.Open(index);
-    }
+    public void OpenSidePanel(int index) => _sidePanelManager.Open(index);
     #endregion
 
     #region Refresh
@@ -494,21 +489,21 @@ public class MainViewModel : ViewModelBase, IInitializable, IPostInitializable
             {
                 // Item
                 if (value.StartsWith("item"))
-                    return AvatarExplorerApp.Instance.Items.Get(value)?.Title ?? value;
+                    return InstanceRepository.Items.Get(value)?.Title ?? value;
 
                 // Temp Avatar
                 if (value.StartsWith("tempavatar"))
-                    return AvatarExplorerApp.Instance.TempAvatars.Get(value)?.AvatarName ?? value;
+                    return InstanceRepository.TempAvatars.Get(value)?.AvatarName ?? value;
 
                 // Common Avatar (現在は未実装)
                 if (value.StartsWith("commonavatar"))
-                    return AvatarExplorerApp.Instance.CommonAvatars.Get(value)?.GroupName ?? value;
+                    return InstanceRepository.CommonAvatars.Get(value)?.GroupName ?? value;
 
                 return value;
             }
 
             if (prefix == ItemNavigationService.ItemPrefix)
-                return AvatarExplorerApp.Instance.Items.Get(state)?.Title ?? value;
+                return InstanceRepository.Items.Get(state)?.Title ?? value;
 
             if (prefix == ItemNavigationService.FolderPrefix)
                 return System.IO.Path.GetFileName(_itemNavigationService.ResolveFolderPath(state) ?? "Unknown Folder");
@@ -694,6 +689,9 @@ public class MainViewModel : ViewModelBase, IInitializable, IPostInitializable
         RightPageInfo.Reset();
         Refresh(false);
     }
+
+    private static void OpenSettings() => InstanceRepository.MainWindow.SettingsVM.Open();
+    private static void OpenItemEditor() => InstanceRepository.MainWindow.ItemEditorVM.Open();
     #endregion
 
     #region Side Panel

--- a/AvatarExplorer.UI/ViewModels/MainViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/MainViewModel.cs
@@ -104,7 +104,7 @@ public class MainViewModel : ViewModelBase, IInitializable, IPostInitializable
     private readonly Guid _preLevel1StateGuid = Guid.NewGuid();
     private bool _isPreviousScreenSearch = false;
 
-    private static UserPreferences UserPreferences => InstanceRepository.UserPreferences.Settings;
+    private static UserPreferences UserPreferences => InstanceRepository.UserPreferences;
     #endregion
 
     #region Constructor
@@ -151,7 +151,7 @@ public class MainViewModel : ViewModelBase, IInitializable, IPostInitializable
         InitializeSubscriptions();
 
         Localizer.Instance.LanguageChanged += RefreshAllItems;
-        InstanceRepository.UserPreferences.OnSettingsChanged += _ =>
+        InstanceRepository.UserPreferencesRepository.OnSettingsChanged += _ =>
         {
             UpdateItemsPerPage();
             Refresh();

--- a/AvatarExplorer.UI/ViewModels/MainWindowViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/MainWindowViewModel.cs
@@ -21,8 +21,6 @@ using AvatarExplorer.UI.Services;
 using AvatarExplorer.UI.Services.System;
 using AvatarExplorer.UI.Utils;
 using AvatarExplorer.UI.ViewModels.Overlays;
-using Message.Avalonia;
-using Message.Avalonia.Models;
 using ReactiveUI.Fody.Helpers;
 
 namespace AvatarExplorer.UI.ViewModels;
@@ -34,7 +32,6 @@ public class MainWindowViewModel : ViewModelBase, IInitializable, IPostInitializ
     [Reactive] public IBrush? Background { get; set; } = null;
     [Reactive] public FontFamily FontFamily { get; set; } = FontUtils.GetFontFamily(null);
 
-    public static AvatarExplorerApp AvatarExplorerApp => AvatarExplorerApp.Instance;
     public static MainWindowViewModel Instance { get; private set; } = null!;
 
     public string? LastDragDropPath { get; set; } = null;
@@ -120,12 +117,12 @@ public class MainWindowViewModel : ViewModelBase, IInitializable, IPostInitializ
 
         UserPreferencesService.Instance.Repository.OnSettingsChanged += ApplyPreferenceSettings;
         Localizer.Instance.LanguageChanged += OnLanguageUpdated;
-        AvatarExplorerApp.ArchivePasswordProvider = GetArchivePassword;
+        InstanceRepository.App.ArchivePasswordProvider = GetArchivePassword;
         UpdateChecker.UpdateAvailable += OnUpdateAvailable;
         SingleInstanceService.OnPipeMessageReceived += OnPipeMessageReceived;
-        AvatarExplorerApp.BackupManager.OnBackupRestored += OnBackupRestored;
+        InstanceRepository.App.BackupManager.OnBackupRestored += OnBackupRestored;
 
-        ApplyPreferenceSettings(UserPreferencesService.Instance.Repository.Settings);
+        ApplyPreferenceSettings(InstanceRepository.UserPreferences.Settings);
         UpdateFontFamily();
         UpdateWindowTitle();
     }
@@ -180,8 +177,8 @@ public class MainWindowViewModel : ViewModelBase, IInitializable, IPostInitializ
 
     private static async void CheckForUpdateOnStartup()
     {
-        var settings = AvatarExplorerApp.Instance.RuntimeSettings.Settings;
-        if (!settings.CheckForUpdate) return;
+        var settings = InstanceRepository.RuntimeSettings.Settings;
+        if (!InstanceRepository.RuntimeSettings.Settings.CheckForUpdate) return;
 
         await UpdateChecker.CheckForUpdate(settings.UpdateChannel);
     }
@@ -191,13 +188,13 @@ public class MainWindowViewModel : ViewModelBase, IInitializable, IPostInitializ
         IsUpdateDialogVisible = true;
     }
 
-    private void CheckIfRunningAsAdmin()
+    private static void CheckIfRunningAsAdmin()
     {
         if (!ProcessUtils.IsWindows()) return;
 
         if (SchemeService.IsRunAsAdmin())
         {
-            ShowNotification(
+            NotificationManager.Show(
                 Localizer.Instance[Loc.Warning.Default],
                 Localizer.Instance[Loc.Warning.RunningInAdministratorMode],
                 NotificationType.Warning
@@ -219,7 +216,6 @@ public class MainWindowViewModel : ViewModelBase, IInitializable, IPostInitializ
         FontFamily = FontUtils.GetFontFamily(Localizer.Instance[Loc.FontFamily]);
     }
 
-    public void ShowItemEditor(string? itemId = null) => ItemEditorVM.Open(itemId);
     public void OnFilesDrop(string[] filePaths)
     {
         // ソフト内からD&Dしたアイテムはスキップするように
@@ -236,7 +232,6 @@ public class MainWindowViewModel : ViewModelBase, IInitializable, IPostInitializ
 
         return result;
     }
-
     public async Task<string[]?> ShowSelectAvatars(string title, string[]? avatars = null, bool includeCommonAvatar = false, bool includeTempAvatar = true, bool allowCreateTempAvatar = false)
     {
         SelectAvatarsVisible = true;
@@ -245,7 +240,6 @@ public class MainWindowViewModel : ViewModelBase, IInitializable, IPostInitializ
 
         return result;
     }
-
     public async Task<string[]?> ShowEditTagsDialog(string[]? tags = null)
     {
         IsEditTagsVisible = true;
@@ -254,7 +248,6 @@ public class MainWindowViewModel : ViewModelBase, IInitializable, IPostInitializ
 
         return result;
     }
-
     public async Task<bool> ShowYesNoDialog(string title, string content)
     {
         IsYesNoDialogVisible = true;
@@ -263,17 +256,6 @@ public class MainWindowViewModel : ViewModelBase, IInitializable, IPostInitializ
 
         return result;
     }
-
-    public void ShowTempAvatarResolver(string tempAvatar)
-    {
-        ResolveTempAvatarVM.Open(tempAvatar);
-    }
-
-    public void ShowTagEditor()
-    {
-        TagEditorVM.Open();
-    }
-
     public async Task<string?> ShowTextDialog(string title, string content = "")
     {
         IsTextDialogVisible = true;
@@ -283,7 +265,7 @@ public class MainWindowViewModel : ViewModelBase, IInitializable, IPostInitializ
         return result;
     }
 
-    public async ValueTask<string?> GetArchivePassword(ArchivePasswordRequest request)
+    private async ValueTask<string?> GetArchivePassword(ArchivePasswordRequest request)
     {
         IsArchivePasswordDialogVisible = true;
         var password = await ArchivePasswordDialogVM.ShowAsync(request);
@@ -291,10 +273,6 @@ public class MainWindowViewModel : ViewModelBase, IInitializable, IPostInitializ
 
         return password;
     }
-
-    public void ShowUnitypackageViewer(string filePath) => UnitypackageViewerVM.Open(filePath);
-    public void ShowPdfViewer(string filePath) => PdfViewerVM.Open(filePath);
-    public void ShowErrorLog() => ErrorLogVM.IsVisible = true;
 
     private void SetBackgroundImage(string path, int opacity)
     {
@@ -326,32 +304,6 @@ public class MainWindowViewModel : ViewModelBase, IInitializable, IPostInitializ
         if (application == null) return;
 
         application.RequestedThemeVariant = theme;
-    }
-
-    public static void ShowNotification(string title, string content, NotificationType type)
-    {
-        var manager = MessageManager.Default;
-        var messageOptions = new MessageOptions
-        {
-            Title = title,
-            Duration = TimeSpan.FromSeconds(3.5)
-        };
-
-        switch (type)
-        {
-            case NotificationType.Information:
-                manager.ShowInformationMessage(content, messageOptions);
-                break;
-            case NotificationType.Success:
-                manager.ShowSuccessMessage(content, messageOptions);
-                break;
-            case NotificationType.Warning:
-                manager.ShowWarningMessage(content, messageOptions);
-                break;
-            case NotificationType.Error:
-                manager.ShowErrorMessage(content, messageOptions);
-                break;
-        }
     }
 
     public void OnWindowClosing()

--- a/AvatarExplorer.UI/ViewModels/MainWindowViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/MainWindowViewModel.cs
@@ -115,7 +115,7 @@ public class MainWindowViewModel : ViewModelBase, IInitializable, IPostInitializ
         AppInitializer.StartThumbnailCacheWarmup();
         AppInitializer.StartSingleInstanceService();
 
-        UserPreferencesService.Instance.Repository.OnSettingsChanged += ApplyPreferenceSettings;
+        InstanceRepository.UserPreferencesRepository.OnSettingsChanged += ApplyPreferenceSettings;
         Localizer.Instance.LanguageChanged += OnLanguageUpdated;
         InstanceRepository.App.ArchivePasswordProvider = GetArchivePassword;
         UpdateChecker.UpdateAvailable += OnUpdateAvailable;

--- a/AvatarExplorer.UI/ViewModels/MainWindowViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/MainWindowViewModel.cs
@@ -86,11 +86,6 @@ public class MainWindowViewModel : ViewModelBase, IInitializable, IPostInitializ
         IInitializableRegistry.Register(9999, (IPostInitializable)this);
     }
 
-    private void OnBackupRestored()
-    {
-        AppInitializer.InitializeUserPreferences();
-    }
-
     public async Task Initialize()
     {
         AppInitializer.InitializeApp();
@@ -123,6 +118,51 @@ public class MainWindowViewModel : ViewModelBase, IInitializable, IPostInitializ
         UpdateFontFamily();
         UpdateWindowTitle();
     }
+    private void UpdateFontFamily()
+    {
+        FontFamily = FontUtils.GetFontFamily(Localizer.Instance[Loc.FontFamily]);
+    }
+
+    private void OnBackupRestored()
+    {
+        AppInitializer.InitializeUserPreferences();
+    }
+
+    private static void CheckIfRunningAsAdmin()
+    {
+        if (!ProcessUtils.IsWindows()) return;
+
+        if (SchemeService.IsRunAsAdmin())
+        {
+            NotificationManager.Show(
+                Localizer.Instance[Loc.Warning.Default],
+                Localizer.Instance[Loc.Warning.RunningInAdministratorMode],
+                NotificationType.Warning
+            );
+        }
+    }
+    private void UpdateWindowTitle()
+    {
+        var title = string.Format("VRC Avatar Explorer v{0}", AvatarExplorerApp.CurrentVersion);
+
+        if (ProcessUtils.IsWindows() && SchemeService.IsRunAsAdmin())
+            title += string.Format(" - [{0}]", Localizer.Instance[Loc.Title.AdministratorMode]);
+
+        WindowTitle = title;
+    }
+
+    private static async void CheckForUpdateOnStartup()
+    {
+        var settings = InstanceRepository.RuntimeSettings;
+        if (!InstanceRepository.RuntimeSettings.CheckForUpdate) return;
+
+        await UpdateChecker.CheckForUpdate(settings.UpdateChannel);
+    }
+    private void OnUpdateAvailable(VersionRelease release)
+    {
+        UpdateDialogVM.Open(AvatarExplorerApp.CurrentVersion, release);
+        IsUpdateDialogVisible = true;
+    }
 
     private void OnPipeMessageReceived(string[] args) => Dispatcher.UIThread.Post(() => OnArgsReceived(args));
     public void SetApplicationArgs(string[] args)
@@ -130,7 +170,6 @@ public class MainWindowViewModel : ViewModelBase, IInitializable, IPostInitializ
         ApplicationArgs = args;
         OnArgsReceived(args);
     }
-
     public void OnArgsReceived(string[] args)
     {
         if (args == null || args.Length == 0 || string.IsNullOrEmpty(args[0])) return;
@@ -147,59 +186,6 @@ public class MainWindowViewModel : ViewModelBase, IInitializable, IPostInitializ
             var launchInfo = LaunchInfoService.GetLaunchInfo(uri);
             if (launchInfo != null) ItemEditorVM.Open(launchInfo);
         }
-    }
-
-    private void ApplyPreferenceSettings(UserPreferences settings)
-    {
-        Localizer.Instance.SetLanguage(settings.Language);
-
-        if (settings.UseBackgroundImage) SetBackgroundImage(settings.BackgroundImage, settings.BackgroundOpacity);
-        else BackgroundImage = null;
-
-        var (themeVariant, backgroundColor) = settings.Theme.GetThemeVariant();
-        SetBackgroundColor(backgroundColor);
-        SetTheme(themeVariant);
-    }
-
-    private static async void CheckForUpdateOnStartup()
-    {
-        var settings = InstanceRepository.RuntimeSettings;
-        if (!InstanceRepository.RuntimeSettings.CheckForUpdate) return;
-
-        await UpdateChecker.CheckForUpdate(settings.UpdateChannel);
-    }
-    private void OnUpdateAvailable(VersionRelease release)
-    {
-        UpdateDialogVM.Open(AvatarExplorerApp.CurrentVersion, release);
-        IsUpdateDialogVisible = true;
-    }
-
-    private static void CheckIfRunningAsAdmin()
-    {
-        if (!ProcessUtils.IsWindows()) return;
-
-        if (SchemeService.IsRunAsAdmin())
-        {
-            NotificationManager.Show(
-                Localizer.Instance[Loc.Warning.Default],
-                Localizer.Instance[Loc.Warning.RunningInAdministratorMode],
-                NotificationType.Warning
-            );
-        }
-    }
-
-    private void UpdateWindowTitle()
-    {
-        var title = string.Format("VRC Avatar Explorer v{0}", AvatarExplorerApp.CurrentVersion);
-
-        if (ProcessUtils.IsWindows() && SchemeService.IsRunAsAdmin())
-            title += string.Format(" - [{0}]", Localizer.Instance[Loc.Title.AdministratorMode]);
-
-        WindowTitle = title;
-    }
-    private void UpdateFontFamily()
-    {
-        FontFamily = FontUtils.GetFontFamily(Localizer.Instance[Loc.FontFamily]);
     }
 
     public void OnFilesDrop(string[] filePaths)
@@ -250,7 +236,6 @@ public class MainWindowViewModel : ViewModelBase, IInitializable, IPostInitializ
 
         return result;
     }
-
     private async ValueTask<string?> GetArchivePassword(ArchivePasswordRequest request)
     {
         IsArchivePasswordDialogVisible = true;
@@ -260,6 +245,17 @@ public class MainWindowViewModel : ViewModelBase, IInitializable, IPostInitializ
         return password;
     }
 
+    private void ApplyPreferenceSettings(UserPreferences settings)
+    {
+        Localizer.Instance.SetLanguage(settings.Language);
+
+        if (settings.UseBackgroundImage) SetBackgroundImage(settings.BackgroundImage, settings.BackgroundOpacity);
+        else BackgroundImage = null;
+
+        var (themeVariant, backgroundColor) = settings.Theme.GetThemeVariant();
+        SetBackgroundColor(backgroundColor);
+        SetTheme(themeVariant);
+    }
     private void SetBackgroundImage(string path, int opacity)
     {
         try

--- a/AvatarExplorer.UI/ViewModels/MainWindowViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/MainWindowViewModel.cs
@@ -33,17 +33,28 @@ public class MainWindowViewModel : ViewModelBase, IInitializable, IPostInitializ
     [Reactive] public FontFamily FontFamily { get; set; } = FontUtils.GetFontFamily(null);
 
     public static MainWindowViewModel Instance { get; private set; } = null!;
-
     public string? LastDragDropPath { get; set; } = null;
 
     public MainViewModel MainVM { get; } = new();
-
     public ItemEditorViewModel ItemEditorVM { get; } = new();
-
-    public ArchivePasswordDialogViewModel ArchivePasswordDialogVM { get; } = new();
-    [Reactive] public bool IsArchivePasswordDialogVisible { get; set; }
-
     public EditCommonAvatarsViewModel EditCommonAvatarsVM { get; } = new();
+    public ErrorLogViewModel ErrorLogVM { get; } = new();
+    public FetchAllThumbnailsViewModel FetchAllThumbnailsVM { get; } = new();
+    public FetchAllVariationHashesViewModel FetchAllVariationHashesVM { get; } = new();
+    public ImportDataViewModel ImportDataVM { get; } = new();
+    public ExportDataViewModel ExportDataVM { get; } = new();
+    public ResetDatabaseViewModel ResetDatabaseVM { get; } = new();
+    public InitialSetupViewModel InitialSetupVM { get; } = new();
+    public MergeCategoryViewModel MergeCategoryVM { get; } = new();
+    public TagEditorViewModel TagEditorVM { get; } = new();
+    public PdfViewerViewModel PdfViewerVM { get; } = new();
+    public ProgressViewModel ProgressVM { get; } = new();
+    public ResolveTempAvatarViewModel ResolveTempAvatarVM { get; } = new();
+    public SettingsViewModel SettingsVM { get; } = new();
+    public UnitypackageViewerViewModel UnitypackageViewerVM { get; } = new();
+
+    public TextDialogViewModel TextDialogVM { get; } = new();
+    [Reactive] public bool IsTextDialogVisible { get; set; }
 
     public SelectAvatarsViewModel SelectAvatarsVM { get; } = new();
     [Reactive] public bool SelectAvatarsVisible { get; set; }
@@ -54,39 +65,14 @@ public class MainWindowViewModel : ViewModelBase, IInitializable, IPostInitializ
     public EditTagsViewModel EditTagsVM { get; } = new();
     [Reactive] public bool IsEditTagsVisible { get; set; }
 
-    public ErrorLogViewModel ErrorLogVM { get; } = new();
-
-    public FetchAllThumbnailsViewModel FetchAllThumbnailsVM { get; } = new();
-    public FetchAllVariationHashesViewModel FetchAllVariationHashesVM { get; } = new();
-
-    public ImportDataViewModel ImportDataVM { get; } = new();
-    public ExportDataViewModel ExportDataVM { get; } = new();
-    public ResetDatabaseViewModel ResetDatabaseVM { get; } = new();
-
-    public InitialSetupViewModel InitialSetupVM { get; } = new();
-
-    public MergeCategoryViewModel MergeCategoryVM { get; } = new();
-
-    public TagEditorViewModel TagEditorVM { get; } = new();
-
-    public PdfViewerViewModel PdfViewerVM { get; } = new();
-
-    public ProgressViewModel ProgressVM { get; } = new();
-
-    public ResolveTempAvatarViewModel ResolveTempAvatarVM { get; } = new();
-
-    public SettingsViewModel SettingsVM { get; } = new();
-
-    public TextDialogViewModel TextDialogVM { get; } = new();
-    [Reactive] public bool IsTextDialogVisible { get; set; }
-
-    public UnitypackageViewerViewModel UnitypackageViewerVM { get; } = new();
-
     public UpdateDialogViewModel UpdateDialogVM { get; } = new();
     [Reactive] public bool IsUpdateDialogVisible { get; set; }
 
     public YesNoDialogViewModel YesNoDialogVM { get; } = new();
     [Reactive] public bool IsYesNoDialogVisible { get; set; }
+
+    public ArchivePasswordDialogViewModel ArchivePasswordDialogVM { get; } = new();
+    [Reactive] public bool IsArchivePasswordDialogVisible { get; set; }
 
     public event Action? WindowClosing;
 

--- a/AvatarExplorer.UI/ViewModels/MainWindowViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/MainWindowViewModel.cs
@@ -122,7 +122,7 @@ public class MainWindowViewModel : ViewModelBase, IInitializable, IPostInitializ
         SingleInstanceService.OnPipeMessageReceived += OnPipeMessageReceived;
         InstanceRepository.App.BackupManager.OnBackupRestored += OnBackupRestored;
 
-        ApplyPreferenceSettings(InstanceRepository.UserPreferences.Settings);
+        ApplyPreferenceSettings(InstanceRepository.UserPreferences);
         UpdateFontFamily();
         UpdateWindowTitle();
     }
@@ -177,8 +177,8 @@ public class MainWindowViewModel : ViewModelBase, IInitializable, IPostInitializ
 
     private static async void CheckForUpdateOnStartup()
     {
-        var settings = InstanceRepository.RuntimeSettings.Settings;
-        if (!InstanceRepository.RuntimeSettings.Settings.CheckForUpdate) return;
+        var settings = InstanceRepository.RuntimeSettings;
+        if (!InstanceRepository.RuntimeSettings.CheckForUpdate) return;
 
         await UpdateChecker.CheckForUpdate(settings.UpdateChannel);
     }

--- a/AvatarExplorer.UI/ViewModels/Managers/HoverThumbnailManager.cs
+++ b/AvatarExplorer.UI/ViewModels/Managers/HoverThumbnailManager.cs
@@ -1,5 +1,5 @@
 using Avalonia;
-using AvatarExplorer.UI.Services.System;
+using AvatarExplorer.UI.Services;
 using AvatarExplorer.UI.Services.ViewControl;
 using AvatarExplorer.UI.ViewModels.Component;
 
@@ -14,11 +14,12 @@ public class HoverThumbnailManager(MainViewModel vm)
         var isSuppotedType = item.ViewModelType == ViewModelType.Item || item.ViewModelType == ViewModelType.Avatar || (item.ViewModelType == ViewModelType.File && item.ThumbnailFilePath != null);
         if (!isSuppotedType || item.Thumbnail == null) return;
 
-        var preferences = UserPreferencesService.Instance.Repository.Settings;
-        if (!preferences.EnableHoverIconSize) return;
+        if (InstanceRepository.UserPreferences.Settings.EnableHoverIconSize)
+        {
+            _vm.HoverThumbnailImage = item.Thumbnail;
+            _vm.IsHoverThumbnailVisible = true;
+        }
 
-        _vm.HoverThumbnailImage = item.Thumbnail;
-        _vm.IsHoverThumbnailVisible = true;
     }
 
     public void Hide()

--- a/AvatarExplorer.UI/ViewModels/Managers/HoverThumbnailManager.cs
+++ b/AvatarExplorer.UI/ViewModels/Managers/HoverThumbnailManager.cs
@@ -19,7 +19,6 @@ public class HoverThumbnailManager(MainViewModel vm)
             _vm.HoverThumbnailImage = item.Thumbnail;
             _vm.IsHoverThumbnailVisible = true;
         }
-
     }
 
     public void Hide()

--- a/AvatarExplorer.UI/ViewModels/Managers/HoverThumbnailManager.cs
+++ b/AvatarExplorer.UI/ViewModels/Managers/HoverThumbnailManager.cs
@@ -14,7 +14,7 @@ public class HoverThumbnailManager(MainViewModel vm)
         var isSuppotedType = item.ViewModelType == ViewModelType.Item || item.ViewModelType == ViewModelType.Avatar || (item.ViewModelType == ViewModelType.File && item.ThumbnailFilePath != null);
         if (!isSuppotedType || item.Thumbnail == null) return;
 
-        if (InstanceRepository.UserPreferences.Settings.EnableHoverIconSize)
+        if (InstanceRepository.UserPreferences.EnableHoverIconSize)
         {
             _vm.HoverThumbnailImage = item.Thumbnail;
             _vm.IsHoverThumbnailVisible = true;

--- a/AvatarExplorer.UI/ViewModels/Managers/SidePanelManager.cs
+++ b/AvatarExplorer.UI/ViewModels/Managers/SidePanelManager.cs
@@ -20,11 +20,9 @@ public class SidePanelManager
         ApplyState();
     }
 
-    public void Open(string index)
+    public void Open(int index)
     {
-        if (!int.TryParse(index, out var selected)) return;
-
-        _vm.SelectedSidePanelTab = selected;
+        _vm.SelectedSidePanelTab = index;
         _state = SidePanelState.Expanded;
         _expandedWidth = DefaultExpandedWidth;
         ApplyState();

--- a/AvatarExplorer.UI/ViewModels/Managers/StateCacheManager.cs
+++ b/AvatarExplorer.UI/ViewModels/Managers/StateCacheManager.cs
@@ -7,18 +7,13 @@ using AvatarExplorer.UI.ViewModels.Component;
 
 namespace AvatarExplorer.UI.ViewModels.Managers;
 
-public class StateCacheManager
+public class StateCacheManager(ItemNavigationService navigationService)
 {
     private readonly CacheManager<Guid, int> _pageCache = new(0);
     private readonly CacheManager<Guid, Vector> _scrollValueCache = new(AvaloniaVectorUtils.MaxValue);
     private readonly CacheManager<int, (int, Vector)> _leftStateCache = new((0, AvaloniaVectorUtils.MaxValue));
 
-    private readonly ItemNavigationService _navigationService;
-
-    public StateCacheManager(ItemNavigationService navigationService)
-    {
-        _navigationService = navigationService;
-    }
+    private readonly ItemNavigationService _navigationService = navigationService;
 
     public void SaveLeftState(int categoryIndex, PanelPageInfo leftPageInfo)
     {

--- a/AvatarExplorer.UI/ViewModels/Overlays/ArchivePasswordDialogViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/ArchivePasswordDialogViewModel.cs
@@ -19,13 +19,13 @@ public class ArchivePasswordDialogViewModel : ViewModelBase
     [Reactive] public string Password { get; set; } = string.Empty;
     private TaskCompletionSource<string?> _tcs = new();
 
-    public IReactiveCommand CancelCommand { get; }
     public IReactiveCommand ConfirmCommand { get; }
+    public IReactiveCommand CancelCommand { get; }
 
     public ArchivePasswordDialogViewModel()
     {
-        CancelCommand = ReactiveCommand.Create(() => _tcs.SetResult(null));
-        ConfirmCommand = ReactiveCommand.Create(() => _tcs.SetResult(Password));
+        ConfirmCommand = ReactiveCommand.Create(Confirm);
+        CancelCommand = ReactiveCommand.Create(Cancel);
     }
 
     public Task<string?> ShowAsync(ArchivePasswordRequest request)
@@ -40,4 +40,7 @@ public class ArchivePasswordDialogViewModel : ViewModelBase
         _tcs = new();
         return _tcs.Task;
     }
+
+    public void Confirm() => _tcs.SetResult(Password);
+    public void Cancel() => _tcs.SetResult(null);
 }

--- a/AvatarExplorer.UI/ViewModels/Overlays/EditCommonAvatarsViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/EditCommonAvatarsViewModel.cs
@@ -7,12 +7,10 @@ using Avalonia.Controls.Notifications;
 using AvatarExplorer.Core.Extensions;
 using AvatarExplorer.Core.Localization;
 using AvatarExplorer.Core.Models.Search;
-using AvatarExplorer.Core.Services.System;
-using AvatarExplorer.Core.Services.System.Repositories;
 using AvatarExplorer.UI.Factories;
 using AvatarExplorer.UI.Interfaces;
 using AvatarExplorer.UI.Localization;
-using AvatarExplorer.UI.Models.Settings;
+using AvatarExplorer.UI.Services;
 using AvatarExplorer.UI.Services.Sort;
 using AvatarExplorer.UI.Services.System;
 using AvatarExplorer.UI.ViewModels.Component;
@@ -43,18 +41,14 @@ public class EditCommonAvatarsViewModel : ViewModelBase, IInitializable
     public IReactiveCommand ReplaceAvatarsToGroupCommand { get; }
     public IReactiveCommand CloseCommand { get; }
 
-    private static ItemGroupService ItemService => AvatarExplorerApp.Instance.ItemGroupService;
-    private static CommonAvatarRepository CommonAvatarRep => ItemService.CommonAvatarRepository;
-    private static UserPreferences UserPreferences => UserPreferencesService.Instance.Repository.Settings;
-
     public EditCommonAvatarsViewModel()
     {
         SelectItemCommand = ReactiveCommand.Create<ItemViewModel>(SelectItem);
         AddGroupCommand = ReactiveCommand.CreateFromTask(AddGroup);
         RenameGroupCommand = ReactiveCommand.Create(RenameGroup);
         RemoveGroupCommand = ReactiveCommand.Create(RemoveGroup);
-        SelectVisibleCommand = ReactiveCommand.Create(SelectVisible);
-        UnselectVisibleCommand = ReactiveCommand.Create(UnselectVisible);
+        SelectVisibleCommand = ReactiveCommand.Create(() => SetVisibleStatus(true));
+        UnselectVisibleCommand = ReactiveCommand.Create(() => SetVisibleStatus(false));
         ReplaceAvatarsToGroupCommand = ReactiveCommand.CreateFromTask(ReplaceAvatarsToGroup);
         CloseCommand = ReactiveCommand.Create(Close);
 
@@ -78,7 +72,6 @@ public class EditCommonAvatarsViewModel : ViewModelBase, IInitializable
         SelectedGroupIndex = Groups.Count > 0 ? 0 : -1;
         IsVisible = true;
     }
-
     private void Close()
     {
         SelectedGroupIndex = -1;
@@ -93,21 +86,20 @@ public class EditCommonAvatarsViewModel : ViewModelBase, IInitializable
 
     private async Task AddGroup()
     {
-        var newGroupName = await MainWindowViewModel.Instance.ShowTextDialog(Localizer.Instance[Loc.Dialog.Title.AddCommonAvatarGroup]);
+        var newGroupName = await InstanceRepository.MainWindow.ShowTextDialog(Localizer.Instance[Loc.Dialog.Title.AddCommonAvatarGroup]);
         if (string.IsNullOrEmpty(newGroupName)) return;
 
-        CommonAvatarRep.Create(newGroupName);
+        InstanceRepository.CommonAvatars.Create(newGroupName);
         RefleshGroups();
 
         SelectedGroupIndex = Groups.Count - 1;
     }
-
     private async Task RenameGroup()
     {
         var group = SelectedGroup;
         if (group == null)
         {
-            MainWindowViewModel.ShowNotification(
+            NotificationManager.Show(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.CommonAvatarNotFound],
                 NotificationType.Error
@@ -115,22 +107,21 @@ public class EditCommonAvatarsViewModel : ViewModelBase, IInitializable
             return;
         }
         
-        var newGroupName = await MainWindowViewModel.Instance.ShowTextDialog(
+        var newGroupName = await InstanceRepository.MainWindow.ShowTextDialog(
             Localizer.Instance[Loc.Dialog.Title.NewCommonAvatarGroupName],
             group.DisplayName
         );
         if (string.IsNullOrEmpty(newGroupName)) return;
 
-        CommonAvatarRep.RenameGroup(group.Identifier, newGroupName);
+        InstanceRepository.CommonAvatars.RenameGroup(group.Identifier, newGroupName);
         RefleshGroups();
     }
-
     private async Task RemoveGroup()
     {
         var group = SelectedGroup;
         if (group == null)
         {
-            MainWindowViewModel.ShowNotification(
+            NotificationManager.Show(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.CommonAvatarNotFound],
                 NotificationType.Error
@@ -138,33 +129,27 @@ public class EditCommonAvatarsViewModel : ViewModelBase, IInitializable
             return;
         }
 
-        var confirmationResult = await MainWindowViewModel.Instance.ShowYesNoDialog(
+        var confirmationResult = await InstanceRepository.MainWindow.ShowYesNoDialog(
             Localizer.Instance[Loc.Dialog.Confirmation.Default],
             Localizer.Instance.Get(Loc.Dialog.Confirmation.RemoveCommonAvatarGroup, group.DisplayName)
         );
         if (!confirmationResult) return;
 
-        var replaceToAvatars = await MainWindowViewModel.Instance.ShowYesNoDialog(
+        var replaceToAvatars = await InstanceRepository.MainWindow.ShowYesNoDialog(
             Localizer.Instance[Loc.Dialog.Confirmation.Default],
             Localizer.Instance[Loc.Dialog.Confirmation.EditCommonAvatars.ReplaceGroupToAvatars]
         );
         
-        AvatarExplorerApp.Instance.ItemGroupService.RemoveCommonAvatar(group.Identifier, replaceToAvatars);
+        InstanceRepository.ItemGroupService.RemoveCommonAvatar(group.Identifier, replaceToAvatars);
         RefleshGroups();
 
         if (Groups.Count == 0) SelectedGroupIndex = -1;
         else if (SelectedGroupIndex >= Groups.Count) SelectedGroupIndex = Groups.Count - 1;
     }
 
-    private void SelectVisible()
+    private void SetVisibleStatus(bool status)
     {
-        Avatars.ForEach(i => i.IsSelected = true);
-        UpdateGroupAvatars();
-    }
-
-    private void UnselectVisible()
-    {
-        Avatars.ForEach(i => i.IsSelected = false);
+        Avatars.ForEach(i => i.IsSelected = status);
         UpdateGroupAvatars();
     }
 
@@ -177,7 +162,7 @@ public class EditCommonAvatarsViewModel : ViewModelBase, IInitializable
         }
 
         var searchQuery = searchText + " OR=true";
-        var result = AvatarExplorerApp.Instance.ItemGroupService.SearchItems(searchQuery, SearchResultType.Items | SearchResultType.TempAvatar);
+        var result = InstanceRepository.ItemGroupService.SearchItems(searchQuery, SearchResultType.Items | SearchResultType.TempAvatar);
         if (result == null)
         {
             Avatars = _allAvatars;
@@ -192,38 +177,19 @@ public class EditCommonAvatarsViewModel : ViewModelBase, IInitializable
         var group = SelectedGroup;
         if (group == null) return;
 
-        var confirmationResult = await MainWindowViewModel.Instance.ShowYesNoDialog(
+        var confirmationResult = await InstanceRepository.MainWindow.ShowYesNoDialog(
             Localizer.Instance[Loc.Dialog.Confirmation.Default],
             Localizer.Instance[Loc.Dialog.Confirmation.EditCommonAvatars.ReplaceAvatarsToGroup]
         );
         if (confirmationResult is false) return;
 
-        ItemService.ReplaceSupportedAvatarsToCommonAvatarGroup(group.Identifier);
-    }
-
-    private void RefleshAvatars()
-    {
-        var avatars = ItemService.GetAvatars(includeCommonAvatar: false, includeTempAvatar: true, rawIdentifier: true);
-        var sortedAvatars = ItemSortService.SortAvatars(
-            avatars,
-            UserPreferences.SortOrder,
-            UserPreferences.SortDirection,
-            UserPreferences.RemoveBrackets,
-            rawIdentifier: true
-        );
-
-        _allAvatars = sortedAvatars
-            .Select(NavigationItemFactory.CreateFromNavigationable)
-            .Select(i => i.Update())
-            .ToList();
-
-        Avatars = _allAvatars;
+        InstanceRepository.ItemGroupService.ReplaceSupportedAvatarsToCommonAvatarGroup(group.Identifier);
     }
 
     private void RefleshGroups()
     {
         var lastSelectedGroupIndex = SelectedGroupIndex;
-        var groups = CommonAvatarRep.GetAll();
+        var groups = InstanceRepository.CommonAvatars.GetAll();
 
         Groups = new ObservableCollection<CommonAvatarViewModel>(
             groups.Select(i => new CommonAvatarViewModel()
@@ -239,24 +205,47 @@ public class EditCommonAvatarsViewModel : ViewModelBase, IInitializable
         else if (lastSelectedGroupIndex >= 0 && lastSelectedGroupIndex < Groups.Count) SelectedGroupIndex = lastSelectedGroupIndex;
         else SelectedGroupIndex = 0;
     }
+    private void RefleshAvatars()
+    {
+        var avatars = InstanceRepository.ItemGroupService.GetAvatars(includeCommonAvatar: false, includeTempAvatar: true, rawIdentifier: true);
+        var userPreference = InstanceRepository.UserPreferences.Settings;
+        var sortedAvatars = ItemSortService.SortAvatars(
+            avatars,
+            userPreference.SortOrder,
+            userPreference.SortDirection,
+            userPreference.RemoveBrackets,
+            rawIdentifier: true
+        );
+
+        _allAvatars = sortedAvatars
+            .Select(NavigationItemFactory.CreateFromNavigationable)
+            .Select(i => i.Update())
+            .ToList();
+
+        Avatars = _allAvatars;
+    }
 
     private void UpdateSelectedGroupAvatars()
     {
         var group = SelectedGroup;
         if (group == null) return;
         
-        var commonAvatar = CommonAvatarRep.Get(group.Identifier);
+        var commonAvatar = InstanceRepository.CommonAvatars.Get(group.Identifier);
         if (commonAvatar == null) return;
 
         _allAvatars.ForEach(i => i.IsSelected = commonAvatar.Avatars.Contains(i.Identifier));
         ApplySearchResult(SearchText);
     }
-
     private void UpdateGroupAvatars()
     {
         var group = SelectedGroup;
         if (group == null) return;
 
-        CommonAvatarRep.UpdateAvatars(group.Identifier, _allAvatars.Where(i => i.IsSelected).Select(i => i.Identifier));
+        InstanceRepository.CommonAvatars.UpdateAvatars(
+            group.Identifier,
+            _allAvatars
+                .Where(i => i.IsSelected)
+                .Select(i => i.Identifier)
+        );
     }
 }

--- a/AvatarExplorer.UI/ViewModels/Overlays/EditCommonAvatarsViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/EditCommonAvatarsViewModel.cs
@@ -208,7 +208,7 @@ public class EditCommonAvatarsViewModel : ViewModelBase, IInitializable
     private void RefleshAvatars()
     {
         var avatars = InstanceRepository.ItemGroupService.GetAvatars(includeCommonAvatar: false, includeTempAvatar: true, rawIdentifier: true);
-        var userPreference = InstanceRepository.UserPreferences.Settings;
+        var userPreference = InstanceRepository.UserPreferences;
         var sortedAvatars = ItemSortService.SortAvatars(
             avatars,
             userPreference.SortOrder,

--- a/AvatarExplorer.UI/ViewModels/Overlays/EditMemoViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/EditMemoViewModel.cs
@@ -14,16 +14,17 @@ public class EditMemoViewModel : ViewModelBase
 
     public EditMemoViewModel()
     {
-        ConfirmCommand = ReactiveCommand.Create(() => _tcs.SetResult(Memo));
-        CancelCommand = ReactiveCommand.Create(() => _tcs.SetResult(null));
+        ConfirmCommand = ReactiveCommand.Create(Confirm);
+        CancelCommand = ReactiveCommand.Create(Cancel);
     }
 
     public Task<string?> ShowAsync(string content)
     {
         Memo = content;
-
         _tcs = new();
-
         return _tcs.Task;
     }
+
+    public void Confirm() => _tcs.SetResult(Memo);
+    public void Cancel() => _tcs.SetResult(null);
 }

--- a/AvatarExplorer.UI/ViewModels/Overlays/EditTagsViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/EditTagsViewModel.cs
@@ -4,8 +4,8 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
-using AvatarExplorer.Core.Services.System;
 using AvatarExplorer.UI.Interfaces;
+using AvatarExplorer.UI.Services;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
 
@@ -31,11 +31,10 @@ public class EditTagsViewModel : ViewModelBase, IInitializable
 
     public EditTagsViewModel()
     {
-        ConfirmCommand = ReactiveCommand.Create(() => _tcs.SetResult(Tags.ToArray()));
-        CancelCommand = ReactiveCommand.Create(() => _tcs.SetResult(null));
-
         CreateTagCommand = ReactiveCommand.Create(CreateTag);
-        ClearNewTagCommand = ReactiveCommand.Create(() => NewTag = string.Empty);
+        ClearNewTagCommand = ReactiveCommand.Create(ClearNewTagField);
+        ConfirmCommand = ReactiveCommand.Create(Confirm);
+        CancelCommand = ReactiveCommand.Create(Cancel);
 
         IInitializableRegistry.Register(0, this);
     }
@@ -46,22 +45,28 @@ public class EditTagsViewModel : ViewModelBase, IInitializable
             .Subscribe(_ => ApplySearchFilter());
     }
 
+    public Task<string[]?> ShowAsync(IEnumerable<string>? tags = null)
+    {
+        RefleshTags();
+
+        Tags = new ObservableCollection<string>(tags ?? []);
+        NewTag = string.Empty;
+        SearchText = string.Empty;
+
+        _tcs = new();
+
+        return _tcs.Task;
+    }
+
     public void RefleshTags()
     {
-        _allExistTags = AvatarExplorerApp.Instance.Items.GetAll()
+        _allExistTags = InstanceRepository.Items.GetAll()
             .SelectMany(i => i.Tags)
             .Distinct()
             .ToList();
         ApplySearchFilter();
     }
 
-    private void ApplySearchFilter()
-    {
-        ExistTags = string.IsNullOrWhiteSpace(SearchText)
-            ? _allExistTags
-            : _allExistTags.Where(t => t.Contains(SearchText, StringComparison.OrdinalIgnoreCase)).ToList();
-    }
-    
     public void CreateTag()
     {
         if (!string.IsNullOrEmpty(NewTag) && !Tags.Contains(NewTag))
@@ -69,6 +74,13 @@ public class EditTagsViewModel : ViewModelBase, IInitializable
             Tags.Add(NewTag);
             NewTag = string.Empty;
         }
+    }
+
+    private void ApplySearchFilter()
+    {
+        ExistTags = string.IsNullOrWhiteSpace(SearchText)
+            ? _allExistTags
+            : _allExistTags.Where(t => t.Contains(SearchText, StringComparison.OrdinalIgnoreCase)).ToList();
     }
 
     public void OnTagClick(string tag) => Tags.Remove(tag);
@@ -85,16 +97,7 @@ public class EditTagsViewModel : ViewModelBase, IInitializable
         SelectedIndex = -1;
     }
 
-    public Task<string[]?> ShowAsync(IEnumerable<string>? tags = null)
-    {
-        RefleshTags();
-
-        Tags = new ObservableCollection<string>(tags ?? []);
-        NewTag = string.Empty;
-        SearchText = string.Empty;
-
-        _tcs = new();
-
-        return _tcs.Task;
-    }
+    public void Confirm() => _tcs.SetResult(Tags.ToArray());
+    public void Cancel() => _tcs.SetResult(null);
+    public void ClearNewTagField() => NewTag = string.Empty;
 }

--- a/AvatarExplorer.UI/ViewModels/Overlays/ErrorLogViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/ErrorLogViewModel.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using AvatarExplorer.Core.Data.Paths;
 using AvatarExplorer.Core.Models.Common;
 using AvatarExplorer.Core.Services.System;
-using AvatarExplorer.UI.Services.System;
 using AvatarExplorer.UI.Services.Utilities;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;

--- a/AvatarExplorer.UI/ViewModels/Overlays/ErrorLogViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/ErrorLogViewModel.cs
@@ -19,17 +19,11 @@ public class ErrorLogViewModel : ViewModelBase
 
     public ErrorLogViewModel()
     {
-        CloseCommand = ReactiveCommand.Create(OnClose);
-        OpenFolderCommand = ReactiveCommand.CreateFromTask(OpenFolder);
+        CloseCommand = ReactiveCommand.Create(Close);
+        OpenFolderCommand = ReactiveCommand.CreateFromTask(OpenLogFolder);
     }
 
-    private void OnClose()
-    {
-        IsVisible = false;
-    }
-
-    private async Task OpenFolder()
-    {
-        await LauncherService.OpenFolder(TopLevelProvider.Current, SystemPath.LogsFolderPath);
-    }
+    public void Open() => IsVisible = true;
+    public void Close() => IsVisible = false;
+    public static async Task OpenLogFolder() => await LauncherService.OpenFolder(SystemPath.LogsFolderPath);
 }

--- a/AvatarExplorer.UI/ViewModels/Overlays/ExportDataViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/ExportDataViewModel.cs
@@ -5,9 +5,9 @@ using AvatarExplorer.Core.Extensions;
 using AvatarExplorer.Core.Localization;
 using AvatarExplorer.Core.Models.External;
 using AvatarExplorer.Core.Models.Items;
-using AvatarExplorer.Core.Services.System;
 using AvatarExplorer.UI.Interfaces;
 using AvatarExplorer.UI.Localization;
+using AvatarExplorer.UI.Services;
 using AvatarExplorer.UI.Services.System;
 using AvatarExplorer.UI.Services.Utilities;
 using ReactiveUI;
@@ -41,7 +41,7 @@ public class ExportDataViewModel : ViewModelBase, IInitializable
     {
         BrowseFolderCommand = ReactiveCommand.CreateFromTask(BrowseFolder);
         ExportCommand = ReactiveCommand.CreateFromTask(Export);
-        CancelCommand = ReactiveCommand.Create(() => IsVisible = false);
+        CancelCommand = ReactiveCommand.Create(Close);
 
         IInitializableRegistry.Register(0, this);
     }
@@ -66,7 +66,7 @@ public class ExportDataViewModel : ViewModelBase, IInitializable
 
     private async Task BrowseFolder()
     {
-        var folders = await StorageService.OpenFolderDialog(TopLevelProvider.Current, Localizer.Instance[Loc.Dialog.SelectSaveFolderPath]);
+        var folders = await StorageService.OpenFolderDialog(Localizer.Instance[Loc.Dialog.SelectSaveFolderPath]);
         if (folders == null || folders.Length == 0) return;
 
         FolderPath = folders[0];
@@ -76,11 +76,11 @@ public class ExportDataViewModel : ViewModelBase, IInitializable
     {
         if (string.IsNullOrEmpty(FolderPath)) return;
 
-        var result = await AvatarExplorerApp.Instance.ItemGroupService.Export(SelectedExportType, FolderPath, GetLocalizedType, IncludeCommonToSupported);
+        var result = await InstanceRepository.ItemGroupService.Export(SelectedExportType, FolderPath, GetLocalizedType, IncludeCommonToSupported);
 
         if (result.IsError)
         {
-            MainWindowViewModel.ShowNotification(
+            NotificationManager.Show(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.ExportFailed],
                 NotificationType.Error
@@ -88,13 +88,14 @@ public class ExportDataViewModel : ViewModelBase, IInitializable
         }
         else
         {
-            MainWindowViewModel.ShowNotification(
+            NotificationManager.Show(
                 Localizer.Instance[Loc.Success.Default],
                 Localizer.Instance[Loc.Success.Export],
                 NotificationType.Success
             );
         }
     }
+    private void Close() => IsVisible = false;
 
     private async ValueTask<string?> GetLocalizedType(ItemType type)
     {

--- a/AvatarExplorer.UI/ViewModels/Overlays/FetchAllThumbnailsViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/FetchAllThumbnailsViewModel.cs
@@ -7,6 +7,8 @@ using AvatarExplorer.Core.Extensions;
 using AvatarExplorer.Core.Localization;
 using AvatarExplorer.Core.Services.System;
 using AvatarExplorer.UI.Localization;
+using AvatarExplorer.UI.Services;
+using AvatarExplorer.UI.Services.System;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
 
@@ -73,13 +75,13 @@ public class FetchAllThumbnailsViewModel : ViewModelBase
     {
         if (_isRunning) return;
 
-        var allItems = AvatarExplorerApp.Instance.Items.GetAll()
+        var allItems = InstanceRepository.Items.GetAll()
             .Where(i => i.BoothId != -1)
             .ToArray();
 
         if (allItems.Length == 0)
         {
-            MainWindowViewModel.ShowNotification(
+            NotificationManager.Show(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.ItemNotFound],
                 NotificationType.Error
@@ -115,7 +117,7 @@ public class FetchAllThumbnailsViewModel : ViewModelBase
                 Status = Localizer.Instance[Loc.FetchAllThumbnails.Status.Running];
                 CurrentItem = Localizer.Instance.Get(Loc.FetchAllThumbnails.CurrentItem, item.Title);
 
-                var result = await AvatarExplorerApp.Instance.Items.FetchThumbnailFromBooth(item.Identifier);
+                var result = await InstanceRepository.Items.FetchThumbnailFromBooth(item.Identifier);
                 if (result.IsError)
                 {
                     failureCount++;
@@ -168,7 +170,7 @@ public class FetchAllThumbnailsViewModel : ViewModelBase
         if (isCancelled)
         {
             Status = Localizer.Instance[Loc.FetchAllThumbnails.Status.Cancelled];
-            MainWindowViewModel.ShowNotification(
+            NotificationManager.Show(
                 Localizer.Instance[Loc.Warning.Default],
                 Localizer.Instance.Get(Loc.Warning.FetchAllItemThumbnailsCancelled, [successCount.ToString(), failureCount.ToString(), allItems.Length.ToString()]),
                 NotificationType.Warning
@@ -180,7 +182,7 @@ public class FetchAllThumbnailsViewModel : ViewModelBase
 
         if (failureCount == 0)
         {
-            MainWindowViewModel.ShowNotification(
+            NotificationManager.Show(
                 Localizer.Instance[Loc.Success.Default],
                 Localizer.Instance.Get(Loc.Success.FetchAllItemThumbnails, successCount.ToString()),
                 NotificationType.Success
@@ -188,7 +190,7 @@ public class FetchAllThumbnailsViewModel : ViewModelBase
         }
         else
         {
-            MainWindowViewModel.ShowNotification(
+            NotificationManager.Show(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance.Get(Loc.Error.FetchAllItemThumbnailsFailed, [successCount.ToString(), failureCount.ToString(), allItems.Length.ToString()]),
                 NotificationType.Error

--- a/AvatarExplorer.UI/ViewModels/Overlays/FetchAllVariationHashesViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/FetchAllVariationHashesViewModel.cs
@@ -4,8 +4,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Controls.Notifications;
 using AvatarExplorer.Core.Localization;
-using AvatarExplorer.Core.Services.System;
 using AvatarExplorer.UI.Localization;
+using AvatarExplorer.UI.Services;
+using AvatarExplorer.UI.Services.System;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
 
@@ -72,13 +73,13 @@ public class FetchAllVariationHashesViewModel : ViewModelBase
     {
         if (_isRunning) return;
 
-        var allItems = AvatarExplorerApp.Instance.Items.GetAll()
+        var allItems = InstanceRepository.Items.GetAll()
             .Where(i => i.BoothId != -1)
             .ToArray();
 
         if (allItems.Length == 0)
         {
-            MainWindowViewModel.ShowNotification(
+            NotificationManager.Show(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.ItemNotFound],
                 NotificationType.Error
@@ -114,7 +115,7 @@ public class FetchAllVariationHashesViewModel : ViewModelBase
                 Status = Localizer.Instance[Loc.FetchAllVariationHashes.Status.Running];
                 CurrentItem = Localizer.Instance.Get(Loc.FetchAllVariationHashes.CurrentItem, item.Title);
 
-                var result = await AvatarExplorerApp.Instance.VariationHashes.EnsureVariationHash(item.BoothId.ToString());
+                var result = await InstanceRepository.VariationHashes.EnsureVariationHash(item.BoothId.ToString());
                 if (!result) failureCount++;
                 else successCount++;
 
@@ -160,7 +161,7 @@ public class FetchAllVariationHashesViewModel : ViewModelBase
         if (isCancelled)
         {
             Status = Localizer.Instance[Loc.FetchAllVariationHashes.Status.Cancelled];
-            MainWindowViewModel.ShowNotification(
+            NotificationManager.Show(
                 Localizer.Instance[Loc.Warning.Default],
                 Localizer.Instance.Get(Loc.Warning.FetchAllVariationHashesCancelled, [successCount.ToString(), failureCount.ToString(), allItems.Length.ToString()]),
                 NotificationType.Warning
@@ -172,7 +173,7 @@ public class FetchAllVariationHashesViewModel : ViewModelBase
 
         if (failureCount == 0)
         {
-            MainWindowViewModel.ShowNotification(
+            NotificationManager.Show(
                 Localizer.Instance[Loc.Success.Default],
                 Localizer.Instance.Get(Loc.Success.FetchAllVariationHashes, successCount.ToString()),
                 NotificationType.Success
@@ -180,7 +181,7 @@ public class FetchAllVariationHashesViewModel : ViewModelBase
         }
         else
         {
-            MainWindowViewModel.ShowNotification(
+            NotificationManager.Show(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance.Get(Loc.Error.FetchAllVariationHashesFailed, [successCount.ToString(), failureCount.ToString(), allItems.Length.ToString()]),
                 NotificationType.Error

--- a/AvatarExplorer.UI/ViewModels/Overlays/ImportDataViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/ImportDataViewModel.cs
@@ -47,7 +47,7 @@ public class ImportDataViewModel : ViewModelBase, IInitializable
     {
         BrowseFolderCommand = ReactiveCommand.CreateFromTask(BrowseFolder);
         ImportCommand = ReactiveCommand.CreateFromTask(Import);
-        CancelCommand = ReactiveCommand.Create(() => IsVisible = false);
+        CancelCommand = ReactiveCommand.Create(Cancel);
 
         IInitializableRegistry.Register(0, this);
     }
@@ -138,4 +138,6 @@ public class ImportDataViewModel : ViewModelBase, IInitializable
 
         IsVisible = false;
     }
+
+    private void Cancel() => IsVisible = false;
 }

--- a/AvatarExplorer.UI/ViewModels/Overlays/ImportDataViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/ImportDataViewModel.cs
@@ -6,9 +6,9 @@ using Avalonia.Controls.Notifications;
 using Avalonia.Threading;
 using AvatarExplorer.Core.Localization;
 using AvatarExplorer.Core.Models.External;
-using AvatarExplorer.Core.Services.System;
 using AvatarExplorer.UI.Interfaces;
 using AvatarExplorer.UI.Localization;
+using AvatarExplorer.UI.Services;
 using AvatarExplorer.UI.Services.System;
 using AvatarExplorer.UI.Services.Utilities;
 using ReactiveUI;
@@ -76,7 +76,6 @@ public class ImportDataViewModel : ViewModelBase, IInitializable
     private async Task BrowseFolder()
     {
         var folders = await StorageService.OpenFolderDialog(
-            TopLevelProvider.Current,
             Localizer.Instance[Loc.Dialog.SelectFolderPath],
             allowMultiple: false
         );
@@ -93,7 +92,7 @@ public class ImportDataViewModel : ViewModelBase, IInitializable
         if (ImportItems) type |= DataImportType.Items;
         if (ImportThumbnails) type |= DataImportType.Thumbnails;
 
-        var copyAssetData = await MainWindowViewModel.Instance.ShowYesNoDialog(
+        var copyAssetData = await InstanceRepository.MainWindow.ShowYesNoDialog(
             Localizer.Instance[Loc.Dialog.Confirmation.Default],
             Localizer.Instance[Loc.Dialog.Confirmation.CopyAssetData]
         );
@@ -102,7 +101,7 @@ public class ImportDataViewModel : ViewModelBase, IInitializable
         {
             await Dispatcher.UIThread.InvokeAsync(() =>
             {
-                MainWindowViewModel.Instance.ProgressVM.Update(
+                InstanceRepository.MainWindow.ProgressVM.Update(
                     Localizer.Instance.Get(tuple.localizationKey, tuple.progress.ToString()),
                     tuple.progress
                 );
@@ -117,13 +116,13 @@ public class ImportDataViewModel : ViewModelBase, IInitializable
             ReportProgress = ProgressAction
         };
 
-        MainWindowViewModel.Instance.ProgressVM.Open(Localizer.Instance[Loc.Processing.Import.Copying]);
-        var result = await AvatarExplorerApp.Instance.ItemGroupService.Import(request);
-        MainWindowViewModel.Instance.ProgressVM.Close();
+        InstanceRepository.MainWindow.ProgressVM.Open(Localizer.Instance[Loc.Processing.Import.Copying]);
+        var result = await InstanceRepository.ItemGroupService.Import(request);
+        InstanceRepository.MainWindow.ProgressVM.Close();
 
         if (result.IsError)
         {
-            MainWindowViewModel.ShowNotification(
+            NotificationManager.Show(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.ImportFailed],
                 NotificationType.Error
@@ -131,7 +130,7 @@ public class ImportDataViewModel : ViewModelBase, IInitializable
             return;
         }
 
-        MainWindowViewModel.ShowNotification(
+        NotificationManager.Show(
             Localizer.Instance[Loc.Success.Default],
             Localizer.Instance[Loc.Success.Import],
             NotificationType.Success

--- a/AvatarExplorer.UI/ViewModels/Overlays/InitialSetupViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/InitialSetupViewModel.cs
@@ -6,10 +6,10 @@ using System.Threading.Tasks;
 using Avalonia.Controls.Notifications;
 using AvatarExplorer.Core.Localization;
 using AvatarExplorer.Core.Services.System;
-using AvatarExplorer.Core.Services.System.Repositories;
 using AvatarExplorer.Core.Utils;
 using AvatarExplorer.UI.Interfaces;
 using AvatarExplorer.UI.Localization;
+using AvatarExplorer.UI.Services;
 using AvatarExplorer.UI.Services.System;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
@@ -25,9 +25,6 @@ public class InitialSetupViewModel : ViewModelBase, IInitializable, IPostInitial
     [Reactive] public string ItemsFolder { get; set; } = string.Empty;
 
     public IReactiveCommand CloseCommand { get; }
-
-    private static RuntimeSettingsRepository Settings => AvatarExplorerApp.Instance.RuntimeSettings;
-    private static UserPreferencesRepository UserPreferences => UserPreferencesService.Instance.Repository;
 
     public InitialSetupViewModel()
     {
@@ -50,15 +47,15 @@ public class InitialSetupViewModel : ViewModelBase, IInitializable, IPostInitial
             .Subscribe(path =>
             {
                 if (!IsVisible) return;
-                Settings.Update(Settings.Settings with { DataRootDirectory = path });
+                InstanceRepository.RuntimeSettings.Update(InstanceRepository.RuntimeSettings.Settings with { DataRootDirectory = path });
             });
     }
 
     public async Task OnInitialized()
     {
-        if (UserPreferences.Settings.InitialSetupCompleted) return;
+        if (InstanceRepository.UserPreferences.Settings.InitialSetupCompleted) return;
 
-        if (AvatarExplorerApp.Instance.Items.GetAll().Any())
+        if (InstanceRepository.Items.GetAll().Any())
         {
             MarkInitialSetupCompleted();
             return;
@@ -73,7 +70,7 @@ public class InitialSetupViewModel : ViewModelBase, IInitializable, IPostInitial
         Languages = Localizer.Instance.GetLanguageList();
         SelectedLanguage = -1;
         SelectedLanguage = Localizer.Instance.CurrentLanguageIndex;
-        ItemsFolder = Settings.Settings.DataRootDirectory;
+        ItemsFolder = InstanceRepository.RuntimeSettings.Settings.DataRootDirectory;
 
         IsVisible = true;
     }
@@ -85,13 +82,13 @@ public class InitialSetupViewModel : ViewModelBase, IInitializable, IPostInitial
     }
 
     private static void MarkInitialSetupCompleted() =>
-        UserPreferences.Update(UserPreferences.Settings with { InitialSetupCompleted = true });
+        InstanceRepository.UserPreferences.Update(InstanceRepository.UserPreferences.Settings with { InitialSetupCompleted = true });
 
     private static async void ShowSchemeRegistrationDialog()
     {
         if (SchemeService.IsOwnSchemeRegistered(SchemeService.ProtocolVRCAE)) return;
 
-        var result = await MainWindowViewModel.Instance.ShowYesNoDialog(
+        var result = await InstanceRepository.MainWindow.ShowYesNoDialog(
             Localizer.Instance[Loc.Dialog.Confirmation.Default],
             Localizer.Instance[Loc.Scheme.Register]
         );
@@ -100,7 +97,7 @@ public class InitialSetupViewModel : ViewModelBase, IInitializable, IPostInitial
         {
             if (ProcessUtils.IsWindows() && !SchemeService.IsRunAsAdmin())
             {
-                var restartAsAdmin = await MainWindowViewModel.Instance.ShowYesNoDialog(
+                var restartAsAdmin = await InstanceRepository.MainWindow.ShowYesNoDialog(
                     Localizer.Instance[Loc.Dialog.Confirmation.Default],
                     Localizer.Instance[Loc.Scheme.RestartAsAdmin]
                 );
@@ -110,7 +107,7 @@ public class InitialSetupViewModel : ViewModelBase, IInitializable, IPostInitial
             }
 
             SchemeService.RegisterScheme(SchemeService.ProtocolVRCAE);
-            MainWindowViewModel.ShowNotification(
+            NotificationManager.Show(
                 Localizer.Instance[Loc.Success.Default],
                 Localizer.Instance[Loc.Scheme.RegisterSuccess],
                 NotificationType.Success
@@ -118,7 +115,7 @@ public class InitialSetupViewModel : ViewModelBase, IInitializable, IPostInitial
         }
         else
         {
-            MainWindowViewModel.ShowNotification(
+            NotificationManager.Show(
                 Localizer.Instance[Loc.Dialog.Confirmation.Default],
                 Localizer.Instance[Loc.Scheme.RegisterSkipped],
                 NotificationType.Information

--- a/AvatarExplorer.UI/ViewModels/Overlays/InitialSetupViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/InitialSetupViewModel.cs
@@ -47,13 +47,13 @@ public class InitialSetupViewModel : ViewModelBase, IInitializable, IPostInitial
             .Subscribe(path =>
             {
                 if (!IsVisible) return;
-                InstanceRepository.RuntimeSettings.Update(InstanceRepository.RuntimeSettings.Settings with { DataRootDirectory = path });
+                InstanceRepository.RuntimeSettingsRepository.Update(InstanceRepository.RuntimeSettings with { DataRootDirectory = path });
             });
     }
 
     public async Task OnInitialized()
     {
-        if (InstanceRepository.UserPreferences.Settings.InitialSetupCompleted) return;
+        if (InstanceRepository.UserPreferences.InitialSetupCompleted) return;
 
         if (InstanceRepository.Items.GetAll().Any())
         {
@@ -70,7 +70,7 @@ public class InitialSetupViewModel : ViewModelBase, IInitializable, IPostInitial
         Languages = Localizer.Instance.GetLanguageList();
         SelectedLanguage = -1;
         SelectedLanguage = Localizer.Instance.CurrentLanguageIndex;
-        ItemsFolder = InstanceRepository.RuntimeSettings.Settings.DataRootDirectory;
+        ItemsFolder = InstanceRepository.RuntimeSettings.DataRootDirectory;
 
         IsVisible = true;
     }
@@ -82,7 +82,7 @@ public class InitialSetupViewModel : ViewModelBase, IInitializable, IPostInitial
     }
 
     private static void MarkInitialSetupCompleted() =>
-        InstanceRepository.UserPreferences.Update(InstanceRepository.UserPreferences.Settings with { InitialSetupCompleted = true });
+        InstanceRepository.UserPreferencesRepository.Update(InstanceRepository.UserPreferences with { InitialSetupCompleted = true });
 
     private static async void ShowSchemeRegistrationDialog()
     {

--- a/AvatarExplorer.UI/ViewModels/Overlays/ItemEditorViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/ItemEditorViewModel.cs
@@ -15,6 +15,7 @@ using AvatarExplorer.Core.Services.System;
 using AvatarExplorer.Core.Utils;
 using AvatarExplorer.UI.Localization;
 using AvatarExplorer.UI.Models.System;
+using AvatarExplorer.UI.Services;
 using AvatarExplorer.UI.Services.System;
 using AvatarExplorer.UI.Services.Utilities;
 using AvatarExplorer.UI.ViewModels.Component;
@@ -102,7 +103,7 @@ public class ItemEditorViewModel : ViewModelBase
 
         if (itemId != null)
         {
-            var item = AvatarExplorerApp.Instance.Items.Get(itemId);
+            var item = InstanceRepository.Items.Get(itemId);
             if (item != null)
             {
                 if (item.BoothId != -1) BoothUrl = item.GetBoothLink(Localizer.Instance[Loc.BoothLanguageCode]);
@@ -121,7 +122,7 @@ public class ItemEditorViewModel : ViewModelBase
             SelectedCategoryIndex = 0;
         }
 
-        ShouldLinkToOriginal = AvatarExplorerApp.Instance.RuntimeSettings.Settings.ShouldLinkToOriginal;
+        ShouldLinkToOriginal = InstanceRepository.RuntimeSettings.Settings.ShouldLinkToOriginal;
 
         UpdateCountField();
         IsVisible = true;
@@ -271,8 +272,8 @@ public class ItemEditorViewModel : ViewModelBase
             Tags = Tags
         };
 
-        bool updateResult = await AvatarExplorerApp.Instance.Items.Update(identifier, editContext);
-        MainWindowViewModel.ShowNotification(
+        bool updateResult = await InstanceRepository.Items.Update(identifier, editContext);
+        NotificationManager.Show(
             Localizer.Instance[updateResult ? Loc.Success.Default : Loc.Error.Default],
             Localizer.Instance[updateResult ? Loc.Success.ItemEdit : Loc.Error.ItemEditFailed],
             updateResult ? NotificationType.Success : NotificationType.Error
@@ -297,11 +298,11 @@ public class ItemEditorViewModel : ViewModelBase
 
         if (creationContext.BoothId != -1)
         {
-            var existingSameBoothIdItem = AvatarExplorerApp.Instance.Items.GetAll().FirstOrDefault(i => i.BoothId == creationContext.BoothId);
+            var existingSameBoothIdItem = InstanceRepository.Items.GetAll().FirstOrDefault(i => i.BoothId == creationContext.BoothId);
 
             if (existingSameBoothIdItem != null)
             {
-                var addToExistingItem = await MainWindowViewModel.Instance.ShowYesNoDialog(
+                var addToExistingItem = await InstanceRepository.MainWindow.ShowYesNoDialog(
                     Localizer.Instance[Loc.Dialog.Confirmation.Default],
                     Localizer.Instance[Loc.Dialog.Confirmation.AddToExistingItem]
                 );
@@ -309,8 +310,8 @@ public class ItemEditorViewModel : ViewModelBase
             }
         }
 
-        var item = await AvatarExplorerApp.Instance.Items.Create(creationContext);
-        MainWindowViewModel.ShowNotification(
+        var item = await InstanceRepository.Items.Create(creationContext);
+        NotificationManager.Show(
             Localizer.Instance[Loc.Success.Default],
             Localizer.Instance[Loc.Success.ItemAdd],
             NotificationType.Success
@@ -320,7 +321,7 @@ public class ItemEditorViewModel : ViewModelBase
 
     private static async Task AddPathsInBackground(string identifier, List<ItemPathEntry> itemPaths, bool shouldLinkToOriginal)
     {
-        MainWindowViewModel.ShowNotification(
+        NotificationManager.Show(
             Localizer.Instance[Loc.Processing.Default],
             Localizer.Instance[Loc.Processing.AddContent],
             NotificationType.Information
@@ -328,11 +329,11 @@ public class ItemEditorViewModel : ViewModelBase
 
         try
         {
-            var result = await AvatarExplorerApp.Instance.Items.AddPaths(identifier, itemPaths, shouldLinkToOriginal);
+            var result = await InstanceRepository.Items.AddPaths(identifier, itemPaths, shouldLinkToOriginal);
 
             if (result.IsError)
             {
-                MainWindowViewModel.ShowNotification(
+                NotificationManager.Show(
                     Localizer.Instance[Loc.Error.Default],
                     Localizer.Instance[Loc.Error.AddContentFailed],
                     NotificationType.Error
@@ -340,7 +341,7 @@ public class ItemEditorViewModel : ViewModelBase
             }
             else if (result.Value.ProcessingFailedPaths.Count > 0)
             {
-                MainWindowViewModel.ShowNotification(
+                NotificationManager.Show(
                     Localizer.Instance[Loc.Error.Default],
                     Localizer.Instance.Get(Loc.Error.FoundProcessingFailedPath, result.Value.ProcessingFailedPaths.Count.ToString()),
                     NotificationType.Error
@@ -348,7 +349,7 @@ public class ItemEditorViewModel : ViewModelBase
             }
             else
             {
-                MainWindowViewModel.ShowNotification(
+                NotificationManager.Show(
                     Localizer.Instance[Loc.Success.Default],
                     Localizer.Instance[Loc.Success.ContentAdd],
                     NotificationType.Success
@@ -363,7 +364,6 @@ public class ItemEditorViewModel : ViewModelBase
     private async Task SelectAndAddFolders()
     {
         var folders = await StorageService.OpenFolderDialog(
-            TopLevelProvider.Current,
             Localizer.Instance[Loc.Dialog.SelectFolderPath],
             allowMultiple: true
         );
@@ -375,7 +375,6 @@ public class ItemEditorViewModel : ViewModelBase
     private async Task SelectAndAddFiles()
     {
         var files = await StorageService.OpenFileDialog(
-            TopLevelProvider.Current,
             Localizer.Instance[Loc.Dialog.SelectFilePath],
             allowMultiple: true
         );
@@ -386,12 +385,12 @@ public class ItemEditorViewModel : ViewModelBase
     }
     private async Task AddUrl()
     {
-        var url = await MainWindowViewModel.Instance.ShowTextDialog(Localizer.Instance[Loc.Dialog.Title.AddUrl]);
+        var url = await InstanceRepository.MainWindow.ShowTextDialog(Localizer.Instance[Loc.Dialog.Title.AddUrl]);
         if (string.IsNullOrEmpty(url)) return;
 
         if (!UriUtils.TryParse(url, out var uri))
         {
-            MainWindowViewModel.ShowNotification(
+            NotificationManager.Show(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.InvalidUrl],
                 NotificationType.Error
@@ -405,14 +404,14 @@ public class ItemEditorViewModel : ViewModelBase
     }
     private async Task FetchBoothData()
     {
-        MainWindowViewModel.Instance.ProgressVM.Open(Localizer.Instance[Loc.Processing.Booth.Status.Fetching]);
-        MainWindowViewModel.Instance.ProgressVM.Update(0);
+        InstanceRepository.MainWindow.ProgressVM.Open(Localizer.Instance[Loc.Processing.Booth.Status.Fetching]);
+        InstanceRepository.MainWindow.ProgressVM.Update(0);
         var fetchResult = await BoothService.Fetch(BoothUrl, waitCooldown: true);
-        MainWindowViewModel.Instance.ProgressVM.Close();
+        InstanceRepository.MainWindow.ProgressVM.Close();
 
         if (fetchResult.IsError)
         {
-            MainWindowViewModel.ShowNotification(
+            NotificationManager.Show(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.RetrieveBoothItemFailed],
                 NotificationType.Error
@@ -433,8 +432,7 @@ public class ItemEditorViewModel : ViewModelBase
 
     private void RefleshCategories()
     {
-        var itemGroupService = AvatarExplorerApp.Instance.ItemGroupService;
-        var categories = itemGroupService.GetCategoryFolders(includeEmptyCategory: true)
+        var categories = InstanceRepository.ItemGroupService.GetCategoryFolders(includeEmptyCategory: true)
             .Select(i => ResolveCategory(i.Identifier))
             .Where(i => i != null)
             .Cast<ItemCategory>();
@@ -463,7 +461,7 @@ public class ItemEditorViewModel : ViewModelBase
 
     private async Task AddCustomCategory()
     {
-        var newCategory = await MainWindowViewModel.Instance.ShowTextDialog(Localizer.Instance[Loc.Dialog.Title.AddCustomCategory]);
+        var newCategory = await InstanceRepository.MainWindow.ShowTextDialog(Localizer.Instance[Loc.Dialog.Title.AddCustomCategory]);
         if (string.IsNullOrEmpty(newCategory)) return;
 
         Categories.Add(new ItemCategoryViewModel(new ItemCategory(newCategory)).Update());
@@ -472,7 +470,7 @@ public class ItemEditorViewModel : ViewModelBase
 
     private async Task SelectSupportedAvatars()
     {
-        var avatars = await MainWindowViewModel.Instance.ShowSelectAvatars(
+        var avatars = await InstanceRepository.MainWindow.ShowSelectAvatars(
             Localizer.Instance[Loc.SelectAvatars.Title.SupportedAvatars],
             SupportedAvatars.ToArray(),
             includeCommonAvatar: true,
@@ -486,20 +484,19 @@ public class ItemEditorViewModel : ViewModelBase
     }
     private int GetSupportedAvatarsCount()
     {
-        var itemGroup = AvatarExplorerApp.Instance.ItemGroupService;
-        return itemGroup.GetAllSupportedAvatarsIds(SupportedAvatars, false).Length;
+        return InstanceRepository.ItemGroupService.GetAllSupportedAvatarsIds(SupportedAvatars, false).Length;
     }
 
     private async Task EditItemMemo()
     {
-        var newMemo = await MainWindowViewModel.Instance.ShowEditMemoDialog(Memo);
+        var newMemo = await InstanceRepository.MainWindow.ShowEditMemoDialog(Memo);
         if (newMemo == null) return;
 
         Memo = newMemo;
     }
     private async Task EditItemTags()
     {
-        var newTags = await MainWindowViewModel.Instance.ShowEditTagsDialog(Tags.ToArray());
+        var newTags = await InstanceRepository.MainWindow.ShowEditTagsDialog(Tags.ToArray());
         if (newTags == null) return;
 
         Tags = newTags;
@@ -517,7 +514,7 @@ public class ItemEditorViewModel : ViewModelBase
         // Title
         if (string.IsNullOrWhiteSpace(Title))
         {
-            MainWindowViewModel.ShowNotification(
+            NotificationManager.Show(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.Validation.EmptyTitle],
                 NotificationType.Error
@@ -528,7 +525,7 @@ public class ItemEditorViewModel : ViewModelBase
         // Author
         if (string.IsNullOrWhiteSpace(Author))
         {
-            MainWindowViewModel.ShowNotification(
+            NotificationManager.Show(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.Validation.EmptyAuthor],
                 NotificationType.Error
@@ -539,7 +536,7 @@ public class ItemEditorViewModel : ViewModelBase
         // Category
         if (SelectedCategory == null)
         {
-            MainWindowViewModel.ShowNotification(
+            NotificationManager.Show(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.InvalidCategory],
                 NotificationType.Error

--- a/AvatarExplorer.UI/ViewModels/Overlays/ItemEditorViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/ItemEditorViewModel.cs
@@ -122,7 +122,7 @@ public class ItemEditorViewModel : ViewModelBase
             SelectedCategoryIndex = 0;
         }
 
-        ShouldLinkToOriginal = InstanceRepository.RuntimeSettings.Settings.ShouldLinkToOriginal;
+        ShouldLinkToOriginal = InstanceRepository.RuntimeSettings.ShouldLinkToOriginal;
 
         UpdateCountField();
         IsVisible = true;

--- a/AvatarExplorer.UI/ViewModels/Overlays/MergeCategoryViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/MergeCategoryViewModel.cs
@@ -5,9 +5,9 @@ using System.Threading.Tasks;
 using AvatarExplorer.Core.Localization;
 using AvatarExplorer.Core.Models.Items;
 using AvatarExplorer.Core.Services.Items;
-using AvatarExplorer.Core.Services.System;
 using AvatarExplorer.Core.Services.System.Repositories;
 using AvatarExplorer.UI.Localization;
+using AvatarExplorer.UI.Services;
 using AvatarExplorer.UI.ViewModels.Component;
 using DynamicData;
 using ReactiveUI;
@@ -27,7 +27,7 @@ public class MergeCategoryViewModel : ViewModelBase
     public IReactiveCommand CancelCommand { get; }
     public IReactiveCommand MergeCommand { get; }
 
-    private static ItemRepository Items => AvatarExplorerApp.Instance.Items;
+    private static ItemRepository Items => InstanceRepository.Items;
 
     public MergeCategoryViewModel()
     {
@@ -68,8 +68,8 @@ public class MergeCategoryViewModel : ViewModelBase
 
     private void RefleshCategories()
     {
-        var itemGroupService = AvatarExplorerApp.Instance.ItemGroupService;
-        var categories = itemGroupService.GetCategoryFolders(includeEmptyCategory: true, includeAllCategory: false)
+        var categories = InstanceRepository.ItemGroupService
+            .GetCategoryFolders(includeEmptyCategory: true, includeAllCategory: false)
             .Select(i => ResolveCategory(i.Identifier))
             .Where(i => i != null)
             .Cast<ItemCategory>();
@@ -111,7 +111,7 @@ public class MergeCategoryViewModel : ViewModelBase
         var sourceCategoryName = SelectedSourceCategory.DisplayName;
         var targetCategoryName = SelectedTargetCategory.DisplayName;
 
-        var result = await MainWindowViewModel.Instance.ShowYesNoDialog(
+        var result = await InstanceRepository.MainWindow.ShowYesNoDialog(
             Localizer.Instance[Loc.Dialog.Confirmation.Default],
             Localizer.Instance.Get(Loc.Dialog.Confirmation.MergeCategory, [sourceCategoryName, targetCategoryName])
         );

--- a/AvatarExplorer.UI/ViewModels/Overlays/ResetDatabaseViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/ResetDatabaseViewModel.cs
@@ -1,7 +1,7 @@
 using System.Threading.Tasks;
 using AvatarExplorer.Core.Localization;
-using AvatarExplorer.Core.Services.System;
 using AvatarExplorer.UI.Localization;
+using AvatarExplorer.UI.Services;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
 
@@ -23,7 +23,7 @@ public class ResetDatabaseViewModel : ViewModelBase
     public ResetDatabaseViewModel()
     {
         ResetCommand = ReactiveCommand.CreateFromTask(Reset);
-        CancelCommand = ReactiveCommand.Create(() => IsVisible = false);
+        CancelCommand = ReactiveCommand.Create(Close);
     }
 
     public void Open()
@@ -40,39 +40,31 @@ public class ResetDatabaseViewModel : ViewModelBase
     {
         if (!ResetItems && !ResetTempAvatars && !ResetCommonAvatars && !ResetBulkImportPresets && !ResetVariationHashes) return;
 
-        var result = await MainWindowViewModel.Instance.ShowYesNoDialog(
+        var result = await InstanceRepository.MainWindow.ShowYesNoDialog(
             Localizer.Instance[Loc.Dialog.Confirmation.Default],
             Localizer.Instance[Loc.Dialog.Confirmation.ResetDatabase]
         );
         if (!result) return;
 
-        await AvatarExplorerApp.Instance.BackupManager.ExecuteBackup();
+        await InstanceRepository.BackupManager.ExecuteBackup();
 
         if (ResetItems)
-        {
-            AvatarExplorerApp.Instance.Items.Clear();
-        }
+            InstanceRepository.Items.Clear();
 
         if (ResetTempAvatars)
-        {
-            AvatarExplorerApp.Instance.TempAvatars.Clear();
-        }
+            InstanceRepository.TempAvatars.Clear();
 
         if (ResetCommonAvatars)
-        {
-            AvatarExplorerApp.Instance.CommonAvatars.Clear();
-        }
+            InstanceRepository.CommonAvatars.Clear();
 
         if (ResetBulkImportPresets)
-        {
-            AvatarExplorerApp.Instance.BulkImportPresets.Clear();
-        }
+            InstanceRepository.BulkImportPresets.Clear();
 
         if (ResetVariationHashes)
-        {
-            AvatarExplorerApp.Instance.VariationHashes.Clear();
-        }
+            InstanceRepository.VariationHashes.Clear();
 
-        IsVisible = false;
+        Close();
     }
+
+    private void Close() => IsVisible = false;
 }

--- a/AvatarExplorer.UI/ViewModels/Overlays/ResolveTempAvatarViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/ResolveTempAvatarViewModel.cs
@@ -5,11 +5,10 @@ using System.Threading.Tasks;
 using Avalonia.Controls.Notifications;
 using AvatarExplorer.Core.Localization;
 using AvatarExplorer.Core.Models.Search;
-using AvatarExplorer.Core.Services.System;
 using AvatarExplorer.UI.Factories;
 using AvatarExplorer.UI.Interfaces;
 using AvatarExplorer.UI.Localization;
-using AvatarExplorer.UI.Models.Settings;
+using AvatarExplorer.UI.Services;
 using AvatarExplorer.UI.Services.Sort;
 using AvatarExplorer.UI.Services.System;
 using AvatarExplorer.UI.ViewModels.Component;
@@ -30,12 +29,9 @@ public class ResolveTempAvatarViewModel : ViewModelBase, IInitializable
 
     private string? SelectedAvatar { get; set; } = null;
 
-    private static ItemGroupService ItemService => AvatarExplorerApp.Instance.ItemGroupService;
-    private static UserPreferences UserPreferences => UserPreferencesService.Instance.Repository.Settings;
-
     public ResolveTempAvatarViewModel()
     {
-        CancelCommand = ReactiveCommand.Create(() => IsVisible = false);
+        CancelCommand = ReactiveCommand.Create(Close);
         SelectItemCommand = ReactiveCommand.CreateFromTask<ItemViewModel>(SelectItem);
 
         IInitializableRegistry.Register(0, this);
@@ -54,15 +50,17 @@ public class ResolveTempAvatarViewModel : ViewModelBase, IInitializable
         SearchText = string.Empty;
         IsVisible = true;
     }
+    private void Close() => IsVisible = false;
 
     private void RefreshAvatars()
     {
-        var avatars = ItemService.GetAvatars(includeCommonAvatar: false, includeTempAvatar: true, rawIdentifier: true);
+        var avatars = InstanceRepository.ItemGroupService.GetAvatars(includeCommonAvatar: false, includeTempAvatar: true, rawIdentifier: true);
+        var userPreference = InstanceRepository.UserPreferences.Settings;
         var sortedAvatars = ItemSortService.SortAvatars(
             avatars,
-            UserPreferences.SortOrder,
-            UserPreferences.SortDirection,
-            UserPreferences.RemoveBrackets,
+            userPreference.SortOrder,
+            userPreference.SortDirection,
+            userPreference.RemoveBrackets,
             rawIdentifier: true
         );
         
@@ -74,6 +72,39 @@ public class ResolveTempAvatarViewModel : ViewModelBase, IInitializable
         Avatars = _allAvatars;
     }
 
+    private async Task SelectItem(ItemViewModel item)
+    {
+        if (SelectedAvatar == null)
+        {
+            NotificationManager.Show(
+                Localizer.Instance[Loc.Error.Default],
+                Localizer.Instance[Loc.Error.TempAvatarNotFound],
+                NotificationType.Error
+            );
+            return;
+        }
+
+        var tempAvatar = InstanceRepository.TempAvatars.Get(SelectedAvatar);
+        if (tempAvatar == null)
+        {
+            NotificationManager.Show(
+                Localizer.Instance[Loc.Error.Default],
+                Localizer.Instance[Loc.Error.TempAvatarNotFound],
+                NotificationType.Error
+            );
+            return;
+        }
+
+        var resolveConfirmationResult = await InstanceRepository.MainWindow.ShowYesNoDialog(
+            Localizer.Instance[Loc.Dialog.Confirmation.Default],
+            Localizer.Instance.Get(Loc.Dialog.Confirmation.ResolveTempAvatar, [tempAvatar.AvatarName, item.Title])
+        );
+        if (!resolveConfirmationResult) return;
+
+        InstanceRepository.ItemGroupService.ResolveTempAvatar(SelectedAvatar, item.Identifier);
+        IsVisible = false;
+    }
+
     private void ApplySearchResult(string searchText)
     {
         if (string.IsNullOrWhiteSpace(searchText))
@@ -83,7 +114,7 @@ public class ResolveTempAvatarViewModel : ViewModelBase, IInitializable
         }
 
         var searchQuery = searchText + " OR=true";
-        var result = ItemService.SearchItems(searchQuery, SearchResultType.All);
+        var result = InstanceRepository.ItemGroupService.SearchItems(searchQuery, SearchResultType.All);
         if (result == null)
         {
             Avatars = _allAvatars;
@@ -91,38 +122,5 @@ public class ResolveTempAvatarViewModel : ViewModelBase, IInitializable
         }
 
         Avatars = _allAvatars.Where(i => result.Contains(i.Identifier)).ToList();
-    }
-
-    private async Task SelectItem(ItemViewModel item)
-    {
-        if (SelectedAvatar == null)
-        {
-            MainWindowViewModel.ShowNotification(
-                Localizer.Instance[Loc.Error.Default],
-                Localizer.Instance[Loc.Error.TempAvatarNotFound],
-                NotificationType.Error
-            );
-            return;
-        }
-
-        var tempAvatar = AvatarExplorerApp.Instance.TempAvatars.Get(SelectedAvatar);
-        if (tempAvatar == null)
-        {
-            MainWindowViewModel.ShowNotification(
-                Localizer.Instance[Loc.Error.Default],
-                Localizer.Instance[Loc.Error.TempAvatarNotFound],
-                NotificationType.Error
-            );
-            return;
-        }
-
-        var resolveConfirmationResult = await MainWindowViewModel.Instance.ShowYesNoDialog(
-            Localizer.Instance[Loc.Dialog.Confirmation.Default],
-            Localizer.Instance.Get(Loc.Dialog.Confirmation.ResolveTempAvatar, [tempAvatar.AvatarName, item.Title])
-        );
-        if (!resolveConfirmationResult) return;
-
-        AvatarExplorerApp.Instance.ItemGroupService.ResolveTempAvatar(SelectedAvatar, item.Identifier);
-        IsVisible = false;
     }
 }

--- a/AvatarExplorer.UI/ViewModels/Overlays/ResolveTempAvatarViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/ResolveTempAvatarViewModel.cs
@@ -55,7 +55,7 @@ public class ResolveTempAvatarViewModel : ViewModelBase, IInitializable
     private void RefreshAvatars()
     {
         var avatars = InstanceRepository.ItemGroupService.GetAvatars(includeCommonAvatar: false, includeTempAvatar: true, rawIdentifier: true);
-        var userPreference = InstanceRepository.UserPreferences.Settings;
+        var userPreference = InstanceRepository.UserPreferences;
         var sortedAvatars = ItemSortService.SortAvatars(
             avatars,
             userPreference.SortOrder,

--- a/AvatarExplorer.UI/ViewModels/Overlays/SelectAvatarsViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/SelectAvatarsViewModel.cs
@@ -5,13 +5,11 @@ using System.Threading.Tasks;
 using AvatarExplorer.Core.Extensions;
 using AvatarExplorer.Core.Localization;
 using AvatarExplorer.Core.Models.Search;
-using AvatarExplorer.Core.Services.System;
 using AvatarExplorer.UI.Factories;
 using AvatarExplorer.UI.Interfaces;
 using AvatarExplorer.UI.Localization;
-using AvatarExplorer.UI.Models.Settings;
+using AvatarExplorer.UI.Services;
 using AvatarExplorer.UI.Services.Sort;
-using AvatarExplorer.UI.Services.System;
 using AvatarExplorer.UI.ViewModels.Component;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
@@ -32,11 +30,8 @@ public class SelectAvatarsViewModel : ViewModelBase, IInitializable
     public IReactiveCommand UnselectVisibleCommand { get; }
 
     public IReactiveCommand AddTempAvatarCommand { get; }
-    public IReactiveCommand CancelCommand { get; }
     public IReactiveCommand ConfirmCommand { get; }
-
-    private static ItemGroupService ItemService => AvatarExplorerApp.Instance.ItemGroupService;
-    private static UserPreferences UserPreferences => UserPreferencesService.Instance.Repository.Settings;
+    public IReactiveCommand CancelCommand { get; }
 
     private bool IncludeCommonAvatar = false;
     private bool IncludeTempAvatar = true;
@@ -45,11 +40,11 @@ public class SelectAvatarsViewModel : ViewModelBase, IInitializable
     {
         AddTempAvatarCommand = ReactiveCommand.Create(AddTempAvatar);
         SelectItemCommand = ReactiveCommand.Create<ItemViewModel>(SelectItem);
-        SelectVisibleCommand = ReactiveCommand.Create(SelectVisible);
-        UnselectVisibleCommand = ReactiveCommand.Create(UnselectVisible);
+        SelectVisibleCommand = ReactiveCommand.Create(() => SetVisibleStatus(true));
+        UnselectVisibleCommand = ReactiveCommand.Create(() => SetVisibleStatus(false));
 
-        CancelCommand = ReactiveCommand.Create(() => _tcs.SetResult(null));
-        ConfirmCommand = ReactiveCommand.Create(() => _tcs.SetResult(Avatars.Where(i => i.IsSelected).Select(i => i.Identifier).ToArray()));
+        ConfirmCommand = ReactiveCommand.Create(Confirm);
+        CancelCommand = ReactiveCommand.Create(Close);
 
         IInitializableRegistry.Register(0, this);
     }
@@ -58,69 +53,6 @@ public class SelectAvatarsViewModel : ViewModelBase, IInitializable
     {
         this.WhenAnyValue(i => i.SearchText)
             .Subscribe(ApplySearchResult);
-    }
-
-    private void SelectItem(ItemViewModel item)
-    {
-        item.IsSelected = !item.IsSelected;
-    }
-
-    private void SelectVisible()
-    {
-        Avatars.ForEach(i => i.IsSelected = true);
-    }
-
-    private void UnselectVisible()
-    {
-        Avatars.ForEach(i => i.IsSelected = false);
-    }
-
-    private void ApplySearchResult(string searchText)
-    {
-        if (string.IsNullOrWhiteSpace(searchText))
-        {
-            Avatars = _allAvatars;
-            return;
-        }
-
-        var searchQuery = searchText + " OR=true";
-        var result = AvatarExplorerApp.Instance.ItemGroupService.SearchItems(searchQuery, SearchResultType.All);
-        if (result == null)
-        {
-            Avatars = _allAvatars;
-            return;
-        }
-
-        Avatars = _allAvatars.Where(i => result.Contains(i.Identifier)).ToList();
-    }
-
-    private void RefleshAvatars(bool includeCommonAvatar, bool includeTempAvatar)
-    {
-        var avatars = ItemService.GetAvatars(includeCommonAvatar, includeTempAvatar, rawIdentifier: true);
-        var sortedAvatars = ItemSortService.SortAvatars(
-            avatars,
-            UserPreferences.SortOrder,
-            UserPreferences.SortDirection,
-            UserPreferences.RemoveBrackets,
-            rawIdentifier: true
-        );
-
-        _allAvatars = sortedAvatars
-            .Select(NavigationItemFactory.CreateFromNavigationable)
-            .Select(i => i.Update())
-            .ToList();
-
-        Avatars = _allAvatars;
-    }
-
-    private async Task AddTempAvatar()
-    {
-        var newTempAvatarName = await MainWindowViewModel.Instance.ShowTextDialog(Localizer.Instance[Loc.Dialog.Title.NewTempAvatarName]);
-        if (string.IsNullOrEmpty(newTempAvatarName)) return;
-
-        AvatarExplorerApp.Instance.TempAvatars.Create(newTempAvatarName);
-        RefleshAvatars(IncludeCommonAvatar, IncludeTempAvatar);
-        ApplySearchResult(SearchText);
     }
 
     public Task<string[]?> ShowAsync(string title, string[]? avatars = null, bool includeCommonAvatar = false, bool includeTempAvatar = true, bool allowCreateTempAvatar = false)
@@ -134,12 +66,72 @@ public class SelectAvatarsViewModel : ViewModelBase, IInitializable
         RefleshAvatars(IncludeCommonAvatar, IncludeTempAvatar);
 
         if (avatars != null)
-        {
             _allAvatars.ForEach(i => i.IsSelected = avatars.Contains(i.Identifier));
-        }
 
         _tcs = new();
-
         return _tcs.Task;
     }
+
+    private void SelectItem(ItemViewModel item) => item.IsSelected = !item.IsSelected;
+    private void SetVisibleStatus(bool status) => Avatars.ForEach(i => i.IsSelected = status);
+
+    private void ApplySearchResult(string searchText)
+    {
+        if (string.IsNullOrWhiteSpace(searchText))
+        {
+            Avatars = _allAvatars;
+            return;
+        }
+
+        var searchQuery = searchText + " OR=true";
+        var result = InstanceRepository.ItemGroupService.SearchItems(searchQuery, SearchResultType.All);
+        if (result == null)
+        {
+            Avatars = _allAvatars;
+            return;
+        }
+
+        Avatars = _allAvatars.Where(i => result.Contains(i.Identifier)).ToList();
+    }
+
+    private void RefleshAvatars(bool includeCommonAvatar, bool includeTempAvatar)
+    {
+        var avatars = InstanceRepository.ItemGroupService.GetAvatars(includeCommonAvatar, includeTempAvatar, rawIdentifier: true);
+        var userPreference = InstanceRepository.UserPreferences.Settings;
+        var sortedAvatars = ItemSortService.SortAvatars(
+            avatars,
+            userPreference.SortOrder,
+            userPreference.SortDirection,
+            userPreference.RemoveBrackets,
+            rawIdentifier: true
+        );
+
+        _allAvatars = sortedAvatars
+            .Select(NavigationItemFactory.CreateFromNavigationable)
+            .Select(i => i.Update())
+            .ToList();
+
+        Avatars = _allAvatars;
+    }
+
+    private async Task AddTempAvatar()
+    {
+        var newTempAvatarName = await InstanceRepository.MainWindow.ShowTextDialog(Localizer.Instance[Loc.Dialog.Title.NewTempAvatarName]);
+        if (string.IsNullOrEmpty(newTempAvatarName)) return;
+
+        InstanceRepository.TempAvatars.Create(newTempAvatarName);
+        RefleshAvatars(IncludeCommonAvatar, IncludeTempAvatar);
+        ApplySearchResult(SearchText);
+    }
+
+    private void Confirm()
+    {
+        _tcs.SetResult(
+            Avatars
+                .Where(i => i.IsSelected)
+                .Select(i => i.Identifier)
+                .ToArray()
+        );
+    }
+    private void Close() => _tcs.SetResult(null);
 }

--- a/AvatarExplorer.UI/ViewModels/Overlays/SelectAvatarsViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/SelectAvatarsViewModel.cs
@@ -97,7 +97,7 @@ public class SelectAvatarsViewModel : ViewModelBase, IInitializable
     private void RefleshAvatars(bool includeCommonAvatar, bool includeTempAvatar)
     {
         var avatars = InstanceRepository.ItemGroupService.GetAvatars(includeCommonAvatar, includeTempAvatar, rawIdentifier: true);
-        var userPreference = InstanceRepository.UserPreferences.Settings;
+        var userPreference = InstanceRepository.UserPreferences;
         var sortedAvatars = ItemSortService.SortAvatars(
             avatars,
             userPreference.SortOrder,

--- a/AvatarExplorer.UI/ViewModels/Overlays/SettingsViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/SettingsViewModel.cs
@@ -131,8 +131,8 @@ public class SettingsViewModel : ViewModelBase, IInitializable
 
     public void Open()
     {
-        var runtimeSettings = InstanceRepository.RuntimeSettings.Settings;
-        var preferences = InstanceRepository.UserPreferences.Settings;
+        var runtimeSettings = InstanceRepository.RuntimeSettings;
+        var preferences = InstanceRepository.UserPreferences;
 
         Languages = Localizer.Instance.GetLanguageList();
 
@@ -436,10 +436,8 @@ public class SettingsViewModel : ViewModelBase, IInitializable
     }
     private void Apply()
     {
-        InstanceRepository.RuntimeSettings.Update(CreateRuntimeSettings());
-
-        var current = InstanceRepository.UserPreferences.Settings;
-        InstanceRepository.UserPreferences.Update(current with
+        InstanceRepository.RuntimeSettingsRepository.Update(CreateRuntimeSettings());
+        InstanceRepository.UserPreferencesRepository.Update(InstanceRepository.UserPreferences with
         {
             Language = SelectedLanguage,
             Theme = (Theme)SelectedTheme,

--- a/AvatarExplorer.UI/ViewModels/Overlays/SettingsViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/SettingsViewModel.cs
@@ -18,6 +18,7 @@ using AvatarExplorer.UI.Interfaces;
 using AvatarExplorer.UI.Localization;
 using AvatarExplorer.UI.Models.Common;
 using AvatarExplorer.UI.Models.Sort;
+using AvatarExplorer.UI.Services;
 using AvatarExplorer.UI.Services.System;
 using AvatarExplorer.UI.Services.Utilities;
 using ReactiveUI;
@@ -111,8 +112,8 @@ public class SettingsViewModel : ViewModelBase, IInitializable
         OpenSourceCodeCommand = ReactiveCommand.CreateFromTask(OpenSourceCode);
         ViewLicenseCommand = ReactiveCommand.CreateFromTask(ViewLicense);
         ViewThirdPartyLicensesCommand = ReactiveCommand.CreateFromTask(ViewThirdPartyLicenses);
-        CloseCommand = ReactiveCommand.Create(OnClose);
-        ApplyCommand = ReactiveCommand.Create(OnApply);
+        CloseCommand = ReactiveCommand.Create(Close);
+        ApplyCommand = ReactiveCommand.Create(Apply);
 
         IInitializableRegistry.Register(0, this);
     }
@@ -130,8 +131,8 @@ public class SettingsViewModel : ViewModelBase, IInitializable
 
     public void Open()
     {
-        var runtimeSettings = AvatarExplorerApp.Instance.RuntimeSettings.Settings;
-        var preferences = UserPreferencesService.Instance.Repository.Settings;
+        var runtimeSettings = InstanceRepository.RuntimeSettings.Settings;
+        var preferences = InstanceRepository.UserPreferences.Settings;
 
         Languages = Localizer.Instance.GetLanguageList();
 
@@ -167,66 +168,19 @@ public class SettingsViewModel : ViewModelBase, IInitializable
         IsVisible = true;
     }
 
-    public RuntimeSettings CreateRuntimeSettings()
-    {
-        return new RuntimeSettings
-        {
-            DataRootDirectory = ItemsFolderPath,
-            AutoBackupRootDirectory = AutoBackupFolderPath,
-            RemoveOriginal = RemoveOriginal,
-            ShouldLinkToOriginal = LinkToOriginal,
-            AutoBackupInterval = ValueParser.Int(AutoBackupInterval, 5),
-            TreatEmptySupportedAvatarAsNone = TreatEmptySupportedAvatarAsNone,
-            MaxDegreeOfParallelism = ValueParser.Int(MaxDegreeOfParallelism, 4),
-            CheckForUpdate = CheckForUpdate,
-            UpdateChannel = (UpdateChannel)SelectedUpdateChannel
-        };
-    }
-
-    private void OnApply()
-    {
-        AvatarExplorerApp.Instance.RuntimeSettings.Update(CreateRuntimeSettings());
-
-        var current = UserPreferencesService.Instance.Repository.Settings;
-        UserPreferencesService.Instance.Repository.Update(current with
-        {
-            Language = SelectedLanguage,
-            Theme = (Theme)SelectedTheme,
-            RemoveBrackets = RemoveBrackets,
-            NormalIconSize = (int)NormalIconSize,
-            EnableHoverIconSize = EnableHoverIconSize,
-            HoverIconSize = (int)HoverIconSize,
-            AntiAliasingMode = (BitmapAntiAliasingMode)SelectedAntiAliasing,
-            ItemsPerPage = ValueParser.Int(ItemsPerPage, 30),
-            ThumbnailCompressionMaxEdge = (int)ThumbnailCompressionMaxSize,
-            UseBackgroundImage = UseBackgroundImage,
-            BackgroundImage = BackgroundImagePath,
-            BackgroundOpacity = (int)BackgroundImageOpacity,
-            SortOrder = (ItemSortOrder)SelectedSortOrder,
-            SortDirection = SelectedSortDirection,
-            ImplementedSort = (ImplementedSort)SelectedImplementedSort,
-            EnableSearchInFolder = EnableSearchInFolder,
-        });
-    }
-
-    private void OnClose()
-    {
-        IsVisible = false;
-    }
-
     private void OpenTagEditor()
     {
-        MainWindowViewModel.Instance.ShowTagEditor();
+        InstanceRepository.MainWindow.TagEditorVM.Open();
     }
 
     private void OpenCommonAvatarManager()
     {
-        MainWindowViewModel.Instance.EditCommonAvatarsVM.Open();
+        InstanceRepository.MainWindow.EditCommonAvatarsVM.Open();
     }
 
     private async Task OpenBackgroundImage()
     {
-        var files = await StorageService.OpenFileDialog(TopLevelProvider.Current, Localizer.Instance[Loc.Dialog.SelectFilePath]);
+        var files = await StorageService.OpenFileDialog(Localizer.Instance[Loc.Dialog.SelectFilePath]);
         if (files == null || files.Length == 0) return;
 
         BackgroundImagePath = files[0];
@@ -234,7 +188,7 @@ public class SettingsViewModel : ViewModelBase, IInitializable
 
     private async Task OpenItemsFolder()
     {
-        var folders = await StorageService.OpenFolderDialog(TopLevelProvider.Current, Localizer.Instance[Loc.Dialog.SelectFolderPath]);
+        var folders = await StorageService.OpenFolderDialog(Localizer.Instance[Loc.Dialog.SelectFolderPath]);
         if (folders == null || folders.Length == 0) return;
 
         ItemsFolderPath = folders[0];
@@ -242,7 +196,7 @@ public class SettingsViewModel : ViewModelBase, IInitializable
 
     private async Task OpenAutoBackupFolder()
     {
-        var folders = await StorageService.OpenFolderDialog(TopLevelProvider.Current, Localizer.Instance[Loc.Dialog.SelectFolderPath]);
+        var folders = await StorageService.OpenFolderDialog(Localizer.Instance[Loc.Dialog.SelectFolderPath]);
         if (folders == null || folders.Length == 0) return;
 
         AutoBackupFolderPath = folders[0];
@@ -250,67 +204,67 @@ public class SettingsViewModel : ViewModelBase, IInitializable
 
     private void ImportData()
     {
-        MainWindowViewModel.Instance.ImportDataVM.Open();
+        InstanceRepository.MainWindow.ImportDataVM.Open();
     }
 
     private void ExportData()
     {
-        MainWindowViewModel.Instance.ExportDataVM.Open();
+        InstanceRepository.MainWindow.ExportDataVM.Open();
     }
 
     private void FetchAllThumbnails()
     {
-        MainWindowViewModel.Instance.FetchAllThumbnailsVM.Open();
+        InstanceRepository.MainWindow.FetchAllThumbnailsVM.Open();
     }
 
     private void FetchAllVariationHashes()
     {
-        MainWindowViewModel.Instance.FetchAllVariationHashesVM.Open();
+        InstanceRepository.MainWindow.FetchAllVariationHashesVM.Open();
     }
 
     private async Task RestoreFromBackup()
     {
-        var folders = await StorageService.OpenFolderDialog(TopLevelProvider.Current, "Select Items Folder");
+        var folders = await StorageService.OpenFolderDialog(Localizer.Instance[Loc.Dialog.SelectFolderPath]);
         if (folders == null || folders.Length == 0) return;
 
         var selectedBackupPath = folders[0];
-        await AvatarExplorerApp.Instance.BackupManager.RestoreBackup(selectedBackupPath);
+        await InstanceRepository.BackupManager.RestoreBackup(selectedBackupPath);
     }
 
     private async Task AutoFixDatabase()
     {
-        var items = AvatarExplorerApp.Instance.Items.GetAll();
+        var items = InstanceRepository.Items.GetAll();
 
         var avatarExists = items.Any(i => i.Category.Type == ItemType.Avatar);
         var unknownCategoryExists = items.Any(i => (int)i.Category.Type >= 11);
         if (!avatarExists)
         {
-            var result = await MainWindowViewModel.Instance.ShowYesNoDialog(
+            var result = await InstanceRepository.MainWindow.ShowYesNoDialog(
                 Localizer.Instance[Loc.Dialog.Confirmation.Default],
                 Localizer.Instance[Loc.Dialog.Confirmation.NoAvatarsAndValidateType]
             );
 
             if (result)
             {
-                await AvatarExplorerApp.Instance.BackupManager.ExecuteBackup();
-                AvatarExplorerApp.Instance.Items.ValidateAndAutoFixItemType(true);
+                await InstanceRepository.BackupManager.ExecuteBackup();
+                InstanceRepository.Items.ValidateAndAutoFixItemType(true);
             }
         }
         else if (unknownCategoryExists)
         {
-            await AvatarExplorerApp.Instance.BackupManager.ExecuteBackup();
-            AvatarExplorerApp.Instance.Items.ValidateAndAutoFixItemType(false);
+            await InstanceRepository.BackupManager.ExecuteBackup();
+            InstanceRepository.Items.ValidateAndAutoFixItemType(false);
         }
     }
 
     private void ResetDatabase()
     {
-        MainWindowViewModel.Instance.ResetDatabaseVM.Open();
+        InstanceRepository.MainWindow.ResetDatabaseVM.Open();
     }
 
     private void ShowErrorLog()
     {
-        MainWindowViewModel.Instance.ShowErrorLog();
+        InstanceRepository.MainWindow.ErrorLogVM.Open();
     }
 
     private void UpdateSchemeStatus()
@@ -351,7 +305,7 @@ public class SettingsViewModel : ViewModelBase, IInitializable
     {
         if (!ProcessUtils.IsWindows() && !ProcessUtils.IsLinux())
         {
-            MainWindowViewModel.ShowNotification(
+            NotificationManager.Show(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.UnsupportedPlatform],
                 NotificationType.Error
@@ -361,7 +315,7 @@ public class SettingsViewModel : ViewModelBase, IInitializable
 
         if (ProcessUtils.IsWindows() && !SchemeService.IsRunAsAdmin())
         {
-            var result = await MainWindowViewModel.Instance.ShowYesNoDialog(
+            var result = await InstanceRepository.MainWindow.ShowYesNoDialog(
                 Localizer.Instance[Loc.Dialog.Confirmation.Default],
                 Localizer.Instance[Loc.Scheme.RestartAsAdmin]
             );
@@ -373,7 +327,7 @@ public class SettingsViewModel : ViewModelBase, IInitializable
         if (SchemeService.IsAnySchemeRegistered(protocol) && !SchemeService.IsOwnSchemeRegistered(protocol))
         {
             var command = SchemeService.GetRegisteredCommand(protocol) ?? "";
-            var result = await MainWindowViewModel.Instance.ShowYesNoDialog(
+            var result = await InstanceRepository.MainWindow.ShowYesNoDialog(
                 Localizer.Instance[Loc.Dialog.Confirmation.Default],
                 Localizer.Instance.Get(Loc.Settings.RegisterScheme.OverwriteConfirm, command)
             );
@@ -383,7 +337,7 @@ public class SettingsViewModel : ViewModelBase, IInitializable
         SchemeService.RegisterScheme(protocol);
         UpdateSchemeStatus();
 
-        MainWindowViewModel.ShowNotification(
+        NotificationManager.Show(
             Localizer.Instance[Loc.Success.Default],
             Localizer.Instance[Loc.Scheme.RegisterSuccess],
             NotificationType.Success
@@ -394,7 +348,7 @@ public class SettingsViewModel : ViewModelBase, IInitializable
     {
         if (ProcessUtils.IsWindows() && !SchemeService.IsRunAsAdmin())
         {
-            var result = await MainWindowViewModel.Instance.ShowYesNoDialog(
+            var result = await InstanceRepository.MainWindow.ShowYesNoDialog(
                 Localizer.Instance[Loc.Dialog.Confirmation.Default],
                 Localizer.Instance[Loc.Scheme.RestartAsAdmin]
             );
@@ -405,7 +359,7 @@ public class SettingsViewModel : ViewModelBase, IInitializable
 
         if (!SchemeService.IsAnySchemeRegistered(protocol)) return;
 
-        var confirm = await MainWindowViewModel.Instance.ShowYesNoDialog(
+        var confirm = await InstanceRepository.MainWindow.ShowYesNoDialog(
             Localizer.Instance[Loc.Dialog.Confirmation.Default],
             Localizer.Instance[Loc.Settings.RegisterScheme.UnregisterConfirm]
         );
@@ -414,7 +368,7 @@ public class SettingsViewModel : ViewModelBase, IInitializable
         SchemeService.UnregisterScheme(protocol);
         UpdateSchemeStatus();
 
-        MainWindowViewModel.ShowNotification(
+        NotificationManager.Show(
             Localizer.Instance[Loc.Success.Default],
             Localizer.Instance[Loc.Settings.RegisterScheme.UnregisterSuccess],
             NotificationType.Success
@@ -427,7 +381,7 @@ public class SettingsViewModel : ViewModelBase, IInitializable
         var result = await UpdateChecker.CheckForUpdate((UpdateChannel)SelectedUpdateChannel);
         if (!result)
         {
-            MainWindowViewModel.ShowNotification(
+            NotificationManager.Show(
                 Localizer.Instance[Loc.UpdateDialog.NoUpdateAvailableTitle],
                 Localizer.Instance.Get(Loc.UpdateDialog.NoUpdateAvailable, AvatarExplorerApp.CurrentVersion),
                 NotificationType.Information
@@ -435,46 +389,78 @@ public class SettingsViewModel : ViewModelBase, IInitializable
         }
     }
 
-    private async Task OpenTwitter()
-    {
-        await LauncherService.OpenUri(TopLevelProvider.Current, DeveloperLink.TwitterURL);
-    }
-
-    private async Task OpenGithub()
-    {
-        await LauncherService.OpenUri(TopLevelProvider.Current, DeveloperLink.GithubURL);
-    }
-
-    private async Task OpenSourceCode()
-    {
-        await LauncherService.OpenUri(TopLevelProvider.Current, SoftwareLink.RepositoryURL);
-    }
-
+    private async Task OpenTwitter() => await LauncherService.OpenUri(DeveloperLink.TwitterURL);
+    private async Task OpenGithub() => await LauncherService.OpenUri(DeveloperLink.GithubURL);
+    private async Task OpenSourceCode() => await LauncherService.OpenUri(SoftwareLink.RepositoryURL);
     private async Task ViewLicense()
     {
         var licensePath = Path.Combine(AppContext.BaseDirectory, SystemFileName.License);
-        if (File.Exists(licensePath)) await LauncherService.OpenUri(TopLevelProvider.Current, licensePath);
+        if (File.Exists(licensePath)) await LauncherService.OpenUri(licensePath);
         else
         {
-            MainWindowViewModel.ShowNotification(
+            NotificationManager.Show(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.LicenseFileNotFound],
                 NotificationType.Error
             );
         }
     }
-
     private async Task ViewThirdPartyLicenses()
     {
         var licensePath = Path.Combine(AppContext.BaseDirectory, SystemFileName.ThirdPartyLicenses);
-        if (File.Exists(licensePath)) await LauncherService.OpenUri(TopLevelProvider.Current, licensePath);
+        if (File.Exists(licensePath)) await LauncherService.OpenUri(licensePath);
         else
         {
-            MainWindowViewModel.ShowNotification(
+            NotificationManager.Show(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.ThirdPartyLicenseFileNotFound],
                 NotificationType.Error
             );
         }
+    }
+    
+    public RuntimeSettings CreateRuntimeSettings()
+    {
+        return new RuntimeSettings
+        {
+            DataRootDirectory = ItemsFolderPath,
+            AutoBackupRootDirectory = AutoBackupFolderPath,
+            RemoveOriginal = RemoveOriginal,
+            ShouldLinkToOriginal = LinkToOriginal,
+            AutoBackupInterval = ValueParser.Int(AutoBackupInterval, 5),
+            TreatEmptySupportedAvatarAsNone = TreatEmptySupportedAvatarAsNone,
+            MaxDegreeOfParallelism = ValueParser.Int(MaxDegreeOfParallelism, 4),
+            CheckForUpdate = CheckForUpdate,
+            UpdateChannel = (UpdateChannel)SelectedUpdateChannel
+        };
+    }
+    private void Apply()
+    {
+        InstanceRepository.RuntimeSettings.Update(CreateRuntimeSettings());
+
+        var current = InstanceRepository.UserPreferences.Settings;
+        InstanceRepository.UserPreferences.Update(current with
+        {
+            Language = SelectedLanguage,
+            Theme = (Theme)SelectedTheme,
+            RemoveBrackets = RemoveBrackets,
+            NormalIconSize = (int)NormalIconSize,
+            EnableHoverIconSize = EnableHoverIconSize,
+            HoverIconSize = (int)HoverIconSize,
+            AntiAliasingMode = (BitmapAntiAliasingMode)SelectedAntiAliasing,
+            ItemsPerPage = ValueParser.Int(ItemsPerPage, 30),
+            ThumbnailCompressionMaxEdge = (int)ThumbnailCompressionMaxSize,
+            UseBackgroundImage = UseBackgroundImage,
+            BackgroundImage = BackgroundImagePath,
+            BackgroundOpacity = (int)BackgroundImageOpacity,
+            SortOrder = (ItemSortOrder)SelectedSortOrder,
+            SortDirection = SelectedSortDirection,
+            ImplementedSort = (ImplementedSort)SelectedImplementedSort,
+            EnableSearchInFolder = EnableSearchInFolder,
+        });
+    }
+    private void Close()
+    {
+        IsVisible = false;
     }
 }

--- a/AvatarExplorer.UI/ViewModels/Overlays/TagEditorViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/TagEditorViewModel.cs
@@ -3,10 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using AvatarExplorer.Core.Localization;
-using AvatarExplorer.Core.Services.System;
-using AvatarExplorer.Core.Services.System.Repositories;
 using AvatarExplorer.UI.Interfaces;
 using AvatarExplorer.UI.Localization;
+using AvatarExplorer.UI.Services;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
 
@@ -25,8 +24,6 @@ public class TagEditorViewModel : ViewModelBase, IInitializable
     public IReactiveCommand RenameCommand { get; }
     public IReactiveCommand RemoveCommand { get; }
     public IReactiveCommand CloseCommand { get; }
-
-    private static ItemRepository Items => AvatarExplorerApp.Instance.Items;
 
     public TagEditorViewModel()
     {
@@ -65,7 +62,7 @@ public class TagEditorViewModel : ViewModelBase, IInitializable
 
     private void RefleshExistTags()
     {
-        _allExistTags = AvatarExplorerApp.Instance.Items.GetAll()
+        _allExistTags = InstanceRepository.Items.GetAll()
             .SelectMany(i => i.Tags)
             .Distinct()
             .ToList();
@@ -89,12 +86,6 @@ public class TagEditorViewModel : ViewModelBase, IInitializable
             : (filtered.Count > 0 ? 0 : -1);
     }
 
-    public void Close()
-    {
-        SelectedTagIndex = -1;
-        IsVisible = false;
-    }
-
     public async Task Rename()
     {
         if (SelectedTagIndex < 0 || SelectedTagIndex >= ExistTags.Count()) return;
@@ -106,7 +97,7 @@ public class TagEditorViewModel : ViewModelBase, IInitializable
 
         if (IsTagNameExist(targetTagName))
         {
-            var result = await MainWindowViewModel.Instance.ShowYesNoDialog(
+            var result = await InstanceRepository.MainWindow.ShowYesNoDialog(
                 Localizer.Instance[Loc.Dialog.Confirmation.Default],
                 Localizer.Instance.Get(Loc.Dialog.Confirmation.RenameTagAlreadyExist, targetTagName)
             );
@@ -114,33 +105,32 @@ public class TagEditorViewModel : ViewModelBase, IInitializable
         }
         else
         {
-            var result = await MainWindowViewModel.Instance.ShowYesNoDialog(
+            var result = await InstanceRepository.MainWindow.ShowYesNoDialog(
                 Localizer.Instance[Loc.Dialog.Confirmation.Default],
                 Localizer.Instance.Get(Loc.Dialog.Confirmation.RenameTag, [sourceTagName, targetTagName])
             );
             if (!result) return;
         }
 
-        Items.RenameTag(sourceTagName, targetTagName);
+        InstanceRepository.Items.RenameTag(sourceTagName, targetTagName);
 
         SelectedTagIndex = -1;
         RefleshExistTags();
         SelectedTagIndex = ExistTags.ToList().IndexOf(targetTagName);
     }
-
     public async Task Remove()
     {
         if (SelectedTagIndex < 0 || SelectedTagIndex >= ExistTags.Count()) return;
 
         var sourceTagName = ExistTags.ElementAt(SelectedTagIndex);
 
-        var result = await MainWindowViewModel.Instance.ShowYesNoDialog(
+        var result = await InstanceRepository.MainWindow.ShowYesNoDialog(
             Localizer.Instance[Loc.Dialog.Confirmation.Default],
             Localizer.Instance.Get(Loc.Dialog.Confirmation.RemoveTag, sourceTagName)
         );
         if (!result) return;
 
-        Items.RemoveTag(sourceTagName);
+        InstanceRepository.Items.RemoveTag(sourceTagName);
 
         RefleshExistTags();
         SelectedTagIndex = -1;
@@ -148,8 +138,14 @@ public class TagEditorViewModel : ViewModelBase, IInitializable
 
     private static bool IsTagNameExist(string tagName)
     {
-        return AvatarExplorerApp.Instance.Items.GetAll()
+        return InstanceRepository.Items.GetAll()
             .SelectMany(i => i.Tags)
             .Contains(tagName);
+    }
+
+    public void Close()
+    {
+        SelectedTagIndex = -1;
+        IsVisible = false;
     }
 }

--- a/AvatarExplorer.UI/ViewModels/Overlays/TextDialogViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/TextDialogViewModel.cs
@@ -15,8 +15,8 @@ public class TextDialogViewModel : ViewModelBase
 
     public TextDialogViewModel()
     {
-        ConfirmCommand = ReactiveCommand.Create(() => _tcs.SetResult(Content));
-        CancelCommand = ReactiveCommand.Create(() => _tcs.SetResult(null));
+        ConfirmCommand = ReactiveCommand.Create(Confirm);
+        CancelCommand = ReactiveCommand.Create(Cancel);
     }
 
     public Task<string?> ShowAsync(string title, string content = "")
@@ -25,7 +25,9 @@ public class TextDialogViewModel : ViewModelBase
         Content = content;
 
         _tcs = new();
-
         return _tcs.Task;
     }
+
+    private void Confirm() => _tcs.SetResult(Content);
+    private void Cancel() => _tcs.SetResult(null);
 }

--- a/AvatarExplorer.UI/ViewModels/Overlays/UnitypackageViewerViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/UnitypackageViewerViewModel.cs
@@ -38,7 +38,7 @@ public class UnitypackageViewerViewModel : ViewModelBase, IInitializable
     public UnitypackageViewerViewModel()
     {
         ExportCommand = ReactiveCommand.CreateFromTask(Export);
-        CloseCommand = ReactiveCommand.Create(OnClose);
+        CloseCommand = ReactiveCommand.Create(Close);
 
         IInitializableRegistry.Register(0, this);
     }
@@ -136,7 +136,6 @@ public class UnitypackageViewerViewModel : ViewModelBase, IInitializable
 
         var initialPath = Path.GetDirectoryName(UnitypackagePath);
         var folders = await StorageService.OpenFolderDialog(
-            TopLevelProvider.Current,
             Localizer.Instance[Loc.Dialog.SelectFolderPath],
             allowMultiple: false,
             initialPath
@@ -154,7 +153,7 @@ public class UnitypackageViewerViewModel : ViewModelBase, IInitializable
         if (result.IsError)
         {
             ErrorManager.Instance.PostInternalError("Failed to export unitypackage asset.", tag: result.Errors.ToErrorString());
-            MainWindowViewModel.ShowNotification(
+            NotificationManager.Show(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.ExportFailed],
                 NotificationType.Error
@@ -165,7 +164,7 @@ public class UnitypackageViewerViewModel : ViewModelBase, IInitializable
         Status = $"{Localizer.Instance[Loc.Success.Export]}: {result.Value}";
     }
 
-    private void OnClose()
+    private void Close()
     {
         IsVisible = false;
     }

--- a/AvatarExplorer.UI/ViewModels/Overlays/UpdateDialogViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/UpdateDialogViewModel.cs
@@ -2,7 +2,6 @@ using System.Threading.Tasks;
 using AvatarExplorer.Core.Localization;
 using AvatarExplorer.Core.Models.Updates;
 using AvatarExplorer.UI.Localization;
-using AvatarExplorer.UI.Services.System;
 using AvatarExplorer.UI.Services.Utilities;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;

--- a/AvatarExplorer.UI/ViewModels/Overlays/UpdateDialogViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/UpdateDialogViewModel.cs
@@ -12,6 +12,7 @@ namespace AvatarExplorer.UI.ViewModels.Overlays;
 public class UpdateDialogViewModel : ViewModelBase
 {
     [Reactive] public bool IsVisible { get; set; }
+
     private string CurrentVersion { get; set; } = string.Empty;
     private string LatestVersion { get; set; } = string.Empty;
     private string ReleaseDate { get; set; } = string.Empty;
@@ -26,7 +27,7 @@ public class UpdateDialogViewModel : ViewModelBase
     public UpdateDialogViewModel()
     {
         LaterCommand = ReactiveCommand.Create(OnLater);
-        UpdateNowCommand = ReactiveCommand.CreateFromTask(OnUpdateNow);
+        UpdateNowCommand = ReactiveCommand.CreateFromTask(UpdateNow);
     }
 
     public void Open(string currentVersion, VersionRelease latestRelease)
@@ -51,9 +52,9 @@ public class UpdateDialogViewModel : ViewModelBase
         IsVisible = false;
     }
 
-    private async Task OnUpdateNow()
+    private async Task UpdateNow()
     {
-        await LauncherService.OpenUri(TopLevelProvider.Current, ReleaseUrl);
+        await LauncherService.OpenUri(ReleaseUrl);
         IsVisible = false;
     }
 }

--- a/AvatarExplorer.UI/ViewModels/Overlays/YesNoDialogViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/YesNoDialogViewModel.cs
@@ -15,8 +15,8 @@ public class YesNoDialogViewModel : ViewModelBase
 
     public YesNoDialogViewModel()
     {
-        YesCommand = ReactiveCommand.Create(() => _tcs.SetResult(true));
-        NoCommand = ReactiveCommand.Create(() => _tcs.SetResult(false));
+        YesCommand = ReactiveCommand.Create(Yes);
+        NoCommand = ReactiveCommand.Create(No);
     }
 
     public Task<bool> ShowAsync(string title, string content)
@@ -25,7 +25,9 @@ public class YesNoDialogViewModel : ViewModelBase
         Content = content;
 
         _tcs = new();
-
         return _tcs.Task;
     }
+
+    private void Yes() => _tcs.SetResult(true);
+    private void No() => _tcs.SetResult(false);
 }

--- a/AvatarExplorer.UI/ViewModels/Panels/BulkImportPresetViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Panels/BulkImportPresetViewModel.cs
@@ -2,10 +2,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using AvatarExplorer.Core.Localization;
-using AvatarExplorer.Core.Services.System;
 using AvatarExplorer.UI.Data;
 using AvatarExplorer.UI.Interfaces;
 using AvatarExplorer.UI.Localization;
+using AvatarExplorer.UI.Services;
 using AvatarExplorer.UI.Services.ViewControl;
 using AvatarExplorer.UI.ViewModels.Component;
 using ReactiveUI;
@@ -29,7 +29,7 @@ public class BulkImportPresetViewModel : ViewModelBase, IInitializable, IPostIni
     public async Task Initialize()
     {
         Localizer.Instance.LanguageChanged += Reload;
-        AvatarExplorerApp.Instance.BulkImportPresets.OnUpdated += Reload;
+        InstanceRepository.BulkImportPresets.OnUpdated += Reload;
     }
 
     public async Task OnInitialized()
@@ -39,7 +39,7 @@ public class BulkImportPresetViewModel : ViewModelBase, IInitializable, IPostIni
 
     public void Reload()
     {
-        Items = AvatarExplorerApp.Instance.BulkImportPresets.GetAll()
+        Items = InstanceRepository.BulkImportPresets.GetAll()
             .Select(i => {
                 var vm = new ItemViewModel()
                 {
@@ -58,13 +58,13 @@ public class BulkImportPresetViewModel : ViewModelBase, IInitializable, IPostIni
     public static void Select(ItemViewModel presetVm)
     {
         var presetIdentifier = presetVm.Identifier;
-        var preset = AvatarExplorerApp.Instance.BulkImportPresets.Get(presetIdentifier);
+        var preset = InstanceRepository.BulkImportPresets.Get(presetIdentifier);
         if (preset == null) return;
 
-        var bulkVm = MainWindowViewModel.Instance.MainVM.BulkImportVM;
+        var bulkVm = InstanceRepository.MainWindow.MainVM.BulkImportVM;
         foreach (var item in preset.Items) bulkVm.AddItem(item.ItemId, item.FilePath);
 
         // 一括インポートの画面
-        MainWindowViewModel.Instance.MainVM.SelectedSidePanelTab = 1;
+        InstanceRepository.MainWindow.MainVM.SelectedSidePanelTab = 1;
     }
 }

--- a/AvatarExplorer.UI/ViewModels/Panels/BulkImportViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Panels/BulkImportViewModel.cs
@@ -8,9 +8,9 @@ using AvatarExplorer.Core.Extensions;
 using AvatarExplorer.Core.Localization;
 using AvatarExplorer.Core.Models.External;
 using AvatarExplorer.Core.Models.Items;
-using AvatarExplorer.Core.Services.System;
 using AvatarExplorer.UI.Interfaces;
 using AvatarExplorer.UI.Localization;
+using AvatarExplorer.UI.Services;
 using AvatarExplorer.UI.Services.External;
 using AvatarExplorer.UI.Services.System;
 using AvatarExplorer.UI.Services.Utilities;
@@ -44,14 +44,14 @@ public class BulkImportViewModel : ViewModelBase, IInitializable
 
     public async Task Initialize()
     {
-        AvatarExplorerApp.Instance.Items.OnUpdated += RefreshItems;
+        InstanceRepository.Items.OnUpdated += RefreshItems;
         UserPreferencesService.Instance.Repository.OnSettingsChanged += _ => OnUserPreferencesChanged();
         Items.CollectionChanged += (s, e) => OnItemsChanged?.Invoke();
     }
 
     private void OnUserPreferencesChanged()
     {
-        var settings = UserPreferencesService.Instance.Repository.Settings;
+        var settings = InstanceRepository.UserPreferences.Settings;
         foreach (var item in Items)
         {
             item.Update(settings.NormalIconSize, settings.RemoveBrackets);
@@ -64,10 +64,10 @@ public class BulkImportViewModel : ViewModelBase, IInitializable
 
         foreach (var bulkImportItem in Items)
         {
-            var item = AvatarExplorerApp.Instance.Items.Get(bulkImportItem.ItemId);
+            var item = InstanceRepository.Items.Get(bulkImportItem.ItemId);
             if (item == null)
             {
-                MainWindowViewModel.ShowNotification(
+                NotificationManager.Show(
                     Localizer.Instance[Loc.Error.Default],
                     Localizer.Instance[Loc.Error.ItemNotFound],
                     NotificationType.Warning
@@ -78,7 +78,7 @@ public class BulkImportViewModel : ViewModelBase, IInitializable
             var selectedPath = bulkImportItem.SelectedUnitypackagePath;
             if (string.IsNullOrEmpty(selectedPath))
             {
-                MainWindowViewModel.ShowNotification(
+                NotificationManager.Show(
                     Localizer.Instance[Loc.Error.Default],
                     Localizer.Instance[Loc.Error.UnitypackageNotFound],
                     NotificationType.Warning
@@ -97,22 +97,22 @@ public class BulkImportViewModel : ViewModelBase, IInitializable
             }
         }
 
-        MainWindowViewModel.Instance.ProgressVM.Open(Localizer.Instance[Loc.Processing.Unitypackage.Status.Preparing]);
+        InstanceRepository.MainWindow.ProgressVM.Open(Localizer.Instance[Loc.Processing.Unitypackage.Status.Preparing]);
         var importResult = await UnitypackageService.Import(
             itemPathCategoryEntries,
             onProgress: async (name, percent) =>
             {
-                MainWindowViewModel.Instance.ProgressVM.Update(
+                InstanceRepository.MainWindow.ProgressVM.Update(
                     Localizer.Instance.Get(name, percent.ToString()),
                     percent
                 );
             }
         );
-        MainWindowViewModel.Instance.ProgressVM.Close();
+        InstanceRepository.MainWindow.ProgressVM.Close();
 
         if (importResult.ContainsScripts)
         {
-            MainWindowViewModel.ShowNotification(
+            NotificationManager.Show(
                 Localizer.Instance[Loc.Warning.Default],
                 Localizer.Instance[Loc.Warning.ScriptsFoundInUnitypackage],
                 NotificationType.Warning
@@ -121,10 +121,10 @@ public class BulkImportViewModel : ViewModelBase, IInitializable
 
         if (!importResult.IsError && !string.IsNullOrEmpty(importResult.ModifiedUnitypackagePath))
         {
-            var result = await LauncherService.OpenFile(TopLevelProvider.Current, importResult.ModifiedUnitypackagePath);
+            var result = await LauncherService.OpenFile(importResult.ModifiedUnitypackagePath);
             if (result.IsError)
             {
-                MainWindowViewModel.ShowNotification(
+                NotificationManager.Show(
                     Localizer.Instance[Loc.Error.Default],
                     Localizer.Instance[Loc.Error.OpenFileFailed],
                     NotificationType.Error
@@ -133,7 +133,7 @@ public class BulkImportViewModel : ViewModelBase, IInitializable
         }
         else
         {
-            MainWindowViewModel.ShowNotification(
+            NotificationManager.Show(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.BulkImportFailed],
                 NotificationType.Error
@@ -148,10 +148,10 @@ public class BulkImportViewModel : ViewModelBase, IInitializable
 
     private async Task Save()
     {
-        var presetName = await MainWindowViewModel.Instance.ShowTextDialog(Localizer.Instance[Loc.Dialog.Title.NewBulkImportPresetName]);
+        var presetName = await InstanceRepository.MainWindow.ShowTextDialog(Localizer.Instance[Loc.Dialog.Title.NewBulkImportPresetName]);
         if (string.IsNullOrEmpty(presetName)) return;
 
-        AvatarExplorerApp.Instance.BulkImportPresets.Create(
+        InstanceRepository.BulkImportPresets.Create(
             presetName,
             Items
                 .Select(i => new BulkImportItem(i.ItemId, i.SelectedUnitypackagePath))
@@ -163,7 +163,7 @@ public class BulkImportViewModel : ViewModelBase, IInitializable
     {
         if (isFile)
         {
-            var currentItem = AvatarExplorerApp.Instance.ItemNavigationService.GetCurrentItemId();
+            var currentItem = InstanceRepository.NavigationService.GetCurrentItemId();
             if (currentItem == null) return;
 
             AddItem(currentItem, value);
@@ -176,10 +176,10 @@ public class BulkImportViewModel : ViewModelBase, IInitializable
 
     public void AddItem(string itemid, string? filePath = null)
     {
-        var item = AvatarExplorerApp.Instance.Items.Get(itemid);
+        var item = InstanceRepository.Items.Get(itemid);
         if (item == null)
         {
-            MainWindowViewModel.ShowNotification(
+            NotificationManager.Show(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.ItemNotFound],
                 NotificationType.Warning
@@ -191,7 +191,7 @@ public class BulkImportViewModel : ViewModelBase, IInitializable
 
         if (unitypackagePaths.Length == 0)
         {
-            MainWindowViewModel.ShowNotification(
+            NotificationManager.Show(
                 Localizer.Instance[Loc.Error.Default],
                 Localizer.Instance[Loc.Error.UnitypackageNotFound],
                 NotificationType.Warning
@@ -215,7 +215,7 @@ public class BulkImportViewModel : ViewModelBase, IInitializable
             if (index != -1) bulkVm.SelectedUnitypackage = index;
         }
 
-        var settings = UserPreferencesService.Instance.Repository.Settings;
+        var settings = InstanceRepository.UserPreferences.Settings;
         Items.Add(bulkVm.Update(settings.NormalIconSize, settings.RemoveBrackets));
     }
 
@@ -223,10 +223,10 @@ public class BulkImportViewModel : ViewModelBase, IInitializable
     {
         var newItems = new List<BulkImportItemViewModel>();
 
-        var settings = UserPreferencesService.Instance.Repository.Settings;
+        var settings = InstanceRepository.UserPreferences.Settings;
         foreach (var itemVm in Items)
         {
-            var item = AvatarExplorerApp.Instance.Items.Get(itemVm.ItemId);
+            var item = InstanceRepository.Items.Get(itemVm.ItemId);
             if (item == null) continue;
 
             itemVm.ImageFileName = item.ThumbnailFileName;

--- a/AvatarExplorer.UI/ViewModels/Panels/BulkImportViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Panels/BulkImportViewModel.cs
@@ -33,8 +33,8 @@ public class BulkImportViewModel : ViewModelBase, IInitializable
 
     public BulkImportViewModel()
     {
-        CopyCommand = ReactiveCommand.Create<BulkImportItemViewModel>(i => Items.Add(i.Copy().Update()));
-        RemoveCommand = ReactiveCommand.Create<BulkImportItemViewModel>(i => Items.Remove(i));
+        CopyCommand = ReactiveCommand.Create<BulkImportItemViewModel>(CopyItem);
+        RemoveCommand = ReactiveCommand.Create<BulkImportItemViewModel>(RemoveItem);
         ImportCommand = ReactiveCommand.CreateFromTask(Import);
         ResetCommand = ReactiveCommand.Create(Reset);
         SaveCommand = ReactiveCommand.CreateFromTask(Save);
@@ -45,7 +45,7 @@ public class BulkImportViewModel : ViewModelBase, IInitializable
     public async Task Initialize()
     {
         InstanceRepository.Items.OnUpdated += RefreshItems;
-        UserPreferencesService.Instance.Repository.OnSettingsChanged += _ => OnUserPreferencesChanged();
+        InstanceRepository.UserPreferencesRepository.OnSettingsChanged += _ => OnUserPreferencesChanged();
         Items.CollectionChanged += (s, e) => OnItemsChanged?.Invoke();
     }
 
@@ -57,6 +57,9 @@ public class BulkImportViewModel : ViewModelBase, IInitializable
             item.Update(settings.NormalIconSize, settings.RemoveBrackets);
         }
     }
+
+    private void CopyItem(BulkImportItemViewModel item) => Items.Add(item.Copy().Update());
+    private void RemoveItem(BulkImportItemViewModel item) => Items.Remove(item);
 
     private async Task Import()
     {

--- a/AvatarExplorer.UI/ViewModels/Panels/BulkImportViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Panels/BulkImportViewModel.cs
@@ -51,7 +51,7 @@ public class BulkImportViewModel : ViewModelBase, IInitializable
 
     private void OnUserPreferencesChanged()
     {
-        var settings = InstanceRepository.UserPreferences.Settings;
+        var settings = InstanceRepository.UserPreferences;
         foreach (var item in Items)
         {
             item.Update(settings.NormalIconSize, settings.RemoveBrackets);
@@ -215,7 +215,7 @@ public class BulkImportViewModel : ViewModelBase, IInitializable
             if (index != -1) bulkVm.SelectedUnitypackage = index;
         }
 
-        var settings = InstanceRepository.UserPreferences.Settings;
+        var settings = InstanceRepository.UserPreferences;
         Items.Add(bulkVm.Update(settings.NormalIconSize, settings.RemoveBrackets));
     }
 
@@ -223,7 +223,7 @@ public class BulkImportViewModel : ViewModelBase, IInitializable
     {
         var newItems = new List<BulkImportItemViewModel>();
 
-        var settings = InstanceRepository.UserPreferences.Settings;
+        var settings = InstanceRepository.UserPreferences;
         foreach (var itemVm in Items)
         {
             var item = InstanceRepository.Items.Get(itemVm.ItemId);

--- a/AvatarExplorer.UI/Views/MainView.axaml.cs
+++ b/AvatarExplorer.UI/Views/MainView.axaml.cs
@@ -174,7 +174,7 @@ public partial class MainView : UserControl
         if (isVisible)
         {
             _hoverWindow.Show();
-            _hoverWindow.SetSize(InstanceRepository.UserPreferences.Settings.HoverIconSize);
+            _hoverWindow.SetSize(InstanceRepository.UserPreferences.HoverIconSize);
             _hoverWindow.Topmost = false;
             _hoverWindow.Topmost = true;
         }
@@ -187,7 +187,7 @@ public partial class MainView : UserControl
     {
         if (sender is not Image image) return;
 
-        var bitmapInterpolationMode = InstanceRepository.UserPreferences.Settings.AntiAliasingMode.GetInterpolationMode();
+        var bitmapInterpolationMode = InstanceRepository.UserPreferences.AntiAliasingMode.GetInterpolationMode();
         if (bitmapInterpolationMode != BitmapInterpolationMode.None && bitmapInterpolationMode != BitmapInterpolationMode.Unspecified)
             RenderOptions.SetBitmapInterpolationMode(image, bitmapInterpolationMode);
 

--- a/AvatarExplorer.UI/Views/MainView.axaml.cs
+++ b/AvatarExplorer.UI/Views/MainView.axaml.cs
@@ -12,7 +12,7 @@ using Avalonia.Threading;
 using AvatarExplorer.Core.Extensions;
 using AvatarExplorer.Core.Utils;
 using AvatarExplorer.UI.Extensions;
-using AvatarExplorer.UI.Services.System;
+using AvatarExplorer.UI.Services;
 using AvatarExplorer.UI.Services.Utilities;
 using AvatarExplorer.UI.Services.ViewControl;
 using AvatarExplorer.UI.ViewModels;
@@ -27,7 +27,7 @@ public partial class MainView : UserControl
     public MainView()
     {
         InitializeComponent();
-        DataContext = MainWindowViewModel.Instance.MainVM;
+        DataContext = InstanceRepository.MainView;
 
         RegisterSidePanelEvent();
         RegisterPathScrollEvent();
@@ -38,7 +38,7 @@ public partial class MainView : UserControl
 
     private void RegisterWindowClosingEvent()
     {
-        MainWindowViewModel.Instance.WindowClosing += CloseHoverWindow;
+        InstanceRepository.MainWindow.WindowClosing += CloseHoverWindow;
     }
 
     private void RegisterPathScrollEvent()
@@ -174,7 +174,7 @@ public partial class MainView : UserControl
         if (isVisible)
         {
             _hoverWindow.Show();
-            _hoverWindow.SetSize(UserPreferencesService.Instance.Repository.Settings.HoverIconSize);
+            _hoverWindow.SetSize(InstanceRepository.UserPreferences.Settings.HoverIconSize);
             _hoverWindow.Topmost = false;
             _hoverWindow.Topmost = true;
         }
@@ -187,8 +187,7 @@ public partial class MainView : UserControl
     {
         if (sender is not Image image) return;
 
-        var userPreferences = UserPreferencesService.Instance.Repository.Settings;
-        var bitmapInterpolationMode = userPreferences.AntiAliasingMode.GetInterpolationMode();
+        var bitmapInterpolationMode = InstanceRepository.UserPreferences.Settings.AntiAliasingMode.GetInterpolationMode();
         if (bitmapInterpolationMode != BitmapInterpolationMode.None && bitmapInterpolationMode != BitmapInterpolationMode.Unspecified)
             RenderOptions.SetBitmapInterpolationMode(image, bitmapInterpolationMode);
 
@@ -270,7 +269,7 @@ public partial class MainView : UserControl
 
         if (viewModelType == ViewModelType.File && !string.IsNullOrEmpty(item.ActualValue))
         {
-            var storageFile = await StorageService.GetStorageFileFromPath(TopLevelProvider.Current, item.ActualValue);
+            var storageFile = await StorageService.GetStorageFileFromPath(item.ActualValue);
             if (storageFile != null)
             {
                 transferItem.Set(DataFormat.File, storageFile);
@@ -302,7 +301,7 @@ public partial class MainView : UserControl
 
         if (!button.IsPressed) return;
 
-        MainWindowViewModel.Instance.LastDragDropPath = droppedPath;
+        InstanceRepository.MainWindow.LastDragDropPath = droppedPath;
         await DragDrop.DoDragDropAsync(e, dragData, DragDropEffects.Copy);
     }
     private async void OnMainPointerPressed(object? sender, PointerPressedEventArgs e)

--- a/AvatarExplorer.UI/Views/Overlays/ArchivePasswordDialog.axaml.cs
+++ b/AvatarExplorer.UI/Views/Overlays/ArchivePasswordDialog.axaml.cs
@@ -1,5 +1,5 @@
 using Avalonia.Controls;
-using AvatarExplorer.UI.ViewModels;
+using AvatarExplorer.UI.Services;
 
 namespace AvatarExplorer.UI.Views.Overlays;
 
@@ -8,6 +8,6 @@ public partial class ArchivePasswordDialogOverlay : UserControl
     public ArchivePasswordDialogOverlay()
     {
         InitializeComponent();
-        DataContext = MainWindowViewModel.Instance.ArchivePasswordDialogVM;
+        DataContext = InstanceRepository.MainWindow.ArchivePasswordDialogVM;
     }
 }

--- a/AvatarExplorer.UI/Views/Overlays/EditCommonAvatarsOverlay.axaml.cs
+++ b/AvatarExplorer.UI/Views/Overlays/EditCommonAvatarsOverlay.axaml.cs
@@ -1,5 +1,5 @@
 using Avalonia.Controls;
-using AvatarExplorer.UI.ViewModels;
+using AvatarExplorer.UI.Services;
 
 namespace AvatarExplorer.UI.Views.Overlays;
 
@@ -8,6 +8,6 @@ public partial class EditCommonAvatarsOverlay : UserControl
     public EditCommonAvatarsOverlay()
     {
         InitializeComponent();
-        DataContext = MainWindowViewModel.Instance.EditCommonAvatarsVM;
+        DataContext = InstanceRepository.MainWindow.EditCommonAvatarsVM;
     }
 }

--- a/AvatarExplorer.UI/Views/Overlays/EditMemoOverlay.axaml.cs
+++ b/AvatarExplorer.UI/Views/Overlays/EditMemoOverlay.axaml.cs
@@ -1,5 +1,5 @@
 using Avalonia.Controls;
-using AvatarExplorer.UI.ViewModels;
+using AvatarExplorer.UI.Services;
 
 namespace AvatarExplorer.UI.Views.Overlays;
 
@@ -8,6 +8,6 @@ public partial class EditMemoOverlay : UserControl
     public EditMemoOverlay()
     {
         InitializeComponent();
-        DataContext = MainWindowViewModel.Instance.EditMemoVM;
+        DataContext = InstanceRepository.MainWindow.EditMemoVM;
     }
 }

--- a/AvatarExplorer.UI/Views/Overlays/EditTagsOverlay.axaml.cs
+++ b/AvatarExplorer.UI/Views/Overlays/EditTagsOverlay.axaml.cs
@@ -1,6 +1,6 @@
 using Avalonia.Controls;
 using Avalonia.Input;
-using AvatarExplorer.UI.ViewModels;
+using AvatarExplorer.UI.Services;
 using AvatarExplorer.UI.ViewModels.Overlays;
 
 namespace AvatarExplorer.UI.Views.Overlays;
@@ -10,7 +10,7 @@ public partial class EditTagsOverlay : UserControl
     public EditTagsOverlay()
     {
         InitializeComponent();
-        DataContext = MainWindowViewModel.Instance.EditTagsVM;
+        DataContext = InstanceRepository.MainWindow.EditTagsVM;
     }
 
     private void OnTagBorderClick(object? sender, PointerPressedEventArgs e)

--- a/AvatarExplorer.UI/Views/Overlays/ErrorLogOverlay.axaml.cs
+++ b/AvatarExplorer.UI/Views/Overlays/ErrorLogOverlay.axaml.cs
@@ -1,5 +1,5 @@
 using Avalonia.Controls;
-using AvatarExplorer.UI.ViewModels;
+using AvatarExplorer.UI.Services;
 
 namespace AvatarExplorer.UI.Views.Overlays;
 
@@ -8,6 +8,6 @@ public partial class ErrorLogOverlay : UserControl
     public ErrorLogOverlay()
     {
         InitializeComponent();
-        DataContext = MainWindowViewModel.Instance.ErrorLogVM;
+        DataContext = InstanceRepository.MainWindow.ErrorLogVM;
     }
 }

--- a/AvatarExplorer.UI/Views/Overlays/ExportDataOverlay.axaml.cs
+++ b/AvatarExplorer.UI/Views/Overlays/ExportDataOverlay.axaml.cs
@@ -1,5 +1,5 @@
 using Avalonia.Controls;
-using AvatarExplorer.UI.ViewModels;
+using AvatarExplorer.UI.Services;
 
 namespace AvatarExplorer.UI.Views.Overlays;
 
@@ -8,6 +8,6 @@ public partial class ExportDataOverlay : UserControl
     public ExportDataOverlay()
     {
         InitializeComponent();
-        DataContext = MainWindowViewModel.Instance.ExportDataVM;
+        DataContext = InstanceRepository.MainWindow.ExportDataVM;
     }
 }

--- a/AvatarExplorer.UI/Views/Overlays/FetchAllThumbnailsOverlay.axaml.cs
+++ b/AvatarExplorer.UI/Views/Overlays/FetchAllThumbnailsOverlay.axaml.cs
@@ -1,5 +1,5 @@
 using Avalonia.Controls;
-using AvatarExplorer.UI.ViewModels;
+using AvatarExplorer.UI.Services;
 
 namespace AvatarExplorer.UI.Views.Overlays;
 
@@ -8,6 +8,6 @@ public partial class FetchAllThumbnailsOverlay : UserControl
     public FetchAllThumbnailsOverlay()
     {
         InitializeComponent();
-        DataContext = MainWindowViewModel.Instance.FetchAllThumbnailsVM;
+        DataContext = InstanceRepository.MainWindow.FetchAllThumbnailsVM;
     }
 }

--- a/AvatarExplorer.UI/Views/Overlays/FetchAllVariationHashesOverlay.axaml.cs
+++ b/AvatarExplorer.UI/Views/Overlays/FetchAllVariationHashesOverlay.axaml.cs
@@ -1,5 +1,5 @@
 using Avalonia.Controls;
-using AvatarExplorer.UI.ViewModels;
+using AvatarExplorer.UI.Services;
 
 namespace AvatarExplorer.UI.Views.Overlays;
 
@@ -8,6 +8,6 @@ public partial class FetchAllVariationHashesOverlay : UserControl
     public FetchAllVariationHashesOverlay()
     {
         InitializeComponent();
-        DataContext = MainWindowViewModel.Instance.FetchAllVariationHashesVM;
+        DataContext = InstanceRepository.MainWindow.FetchAllVariationHashesVM;
     }
 }

--- a/AvatarExplorer.UI/Views/Overlays/ImportDataOverlay.axaml.cs
+++ b/AvatarExplorer.UI/Views/Overlays/ImportDataOverlay.axaml.cs
@@ -1,5 +1,5 @@
 using Avalonia.Controls;
-using AvatarExplorer.UI.ViewModels;
+using AvatarExplorer.UI.Services;
 
 namespace AvatarExplorer.UI.Views.Overlays;
 
@@ -8,6 +8,6 @@ public partial class ImportDataOverlay : UserControl
     public ImportDataOverlay()
     {
         InitializeComponent();
-        DataContext = MainWindowViewModel.Instance.ImportDataVM;
+        DataContext = InstanceRepository.MainWindow.ImportDataVM;
     }
 }

--- a/AvatarExplorer.UI/Views/Overlays/InitialSetupOverlay.axaml.cs
+++ b/AvatarExplorer.UI/Views/Overlays/InitialSetupOverlay.axaml.cs
@@ -1,5 +1,5 @@
 using Avalonia.Controls;
-using AvatarExplorer.UI.ViewModels;
+using AvatarExplorer.UI.Services;
 
 namespace AvatarExplorer.UI.Views.Overlays;
 
@@ -8,6 +8,6 @@ public partial class InitialSetupOverlay : UserControl
     public InitialSetupOverlay()
     {
         InitializeComponent();
-        DataContext = MainWindowViewModel.Instance.InitialSetupVM;
+        DataContext = InstanceRepository.MainWindow.InitialSetupVM;
     }
 }

--- a/AvatarExplorer.UI/Views/Overlays/ItemEditorOverlay.axaml.cs
+++ b/AvatarExplorer.UI/Views/Overlays/ItemEditorOverlay.axaml.cs
@@ -1,5 +1,5 @@
 using Avalonia.Controls;
-using AvatarExplorer.UI.ViewModels;
+using AvatarExplorer.UI.Services;
 
 namespace AvatarExplorer.UI.Views.Overlays;
 
@@ -8,6 +8,6 @@ public partial class ItemEditorOverlay : UserControl
     public ItemEditorOverlay()
     {
         InitializeComponent();
-        DataContext = MainWindowViewModel.Instance.ItemEditorVM;
+        DataContext = InstanceRepository.MainWindow.ItemEditorVM;
     }
 }

--- a/AvatarExplorer.UI/Views/Overlays/MergeCategoryDialog.axaml.cs
+++ b/AvatarExplorer.UI/Views/Overlays/MergeCategoryDialog.axaml.cs
@@ -1,5 +1,5 @@
 using Avalonia.Controls;
-using AvatarExplorer.UI.ViewModels;
+using AvatarExplorer.UI.Services;
 
 namespace AvatarExplorer.UI.Views.Overlays;
 
@@ -8,6 +8,6 @@ public partial class MergeCategoryDialog : UserControl
     public MergeCategoryDialog()
     {
         InitializeComponent();
-        DataContext = MainWindowViewModel.Instance.MergeCategoryVM;
+        DataContext = InstanceRepository.MainWindow.MergeCategoryVM;
     }
 }

--- a/AvatarExplorer.UI/Views/Overlays/PdfViewerOverlay.axaml.cs
+++ b/AvatarExplorer.UI/Views/Overlays/PdfViewerOverlay.axaml.cs
@@ -1,5 +1,5 @@
 using Avalonia.Controls;
-using AvatarExplorer.UI.ViewModels;
+using AvatarExplorer.UI.Services;
 
 namespace AvatarExplorer.UI.Views.Overlays;
 
@@ -8,6 +8,6 @@ public partial class PdfViewerOverlay : UserControl
     public PdfViewerOverlay()
     {
         InitializeComponent();
-        DataContext = MainWindowViewModel.Instance.PdfViewerVM;
+        DataContext = InstanceRepository.MainWindow.PdfViewerVM;
     }
 }

--- a/AvatarExplorer.UI/Views/Overlays/ProgressOverlay.axaml.cs
+++ b/AvatarExplorer.UI/Views/Overlays/ProgressOverlay.axaml.cs
@@ -1,5 +1,5 @@
 using Avalonia.Controls;
-using AvatarExplorer.UI.ViewModels;
+using AvatarExplorer.UI.Services;
 
 namespace AvatarExplorer.UI.Views.Overlays;
 
@@ -8,6 +8,6 @@ public partial class ProgressOverlay : UserControl
     public ProgressOverlay()
     {
         InitializeComponent();
-        DataContext = MainWindowViewModel.Instance.ProgressVM;
+        DataContext = InstanceRepository.MainWindow.ProgressVM;
     }
 }

--- a/AvatarExplorer.UI/Views/Overlays/ResetDatabaseOverlay.axaml.cs
+++ b/AvatarExplorer.UI/Views/Overlays/ResetDatabaseOverlay.axaml.cs
@@ -1,5 +1,5 @@
 using Avalonia.Controls;
-using AvatarExplorer.UI.ViewModels;
+using AvatarExplorer.UI.Services;
 
 namespace AvatarExplorer.UI.Views.Overlays;
 
@@ -8,6 +8,6 @@ public partial class ResetDatabaseOverlay : UserControl
     public ResetDatabaseOverlay()
     {
         InitializeComponent();
-        DataContext = MainWindowViewModel.Instance.ResetDatabaseVM;
+        DataContext = InstanceRepository.MainWindow.ResetDatabaseVM;
     }
 }

--- a/AvatarExplorer.UI/Views/Overlays/ResolveTempAvatarOverlay.axaml.cs
+++ b/AvatarExplorer.UI/Views/Overlays/ResolveTempAvatarOverlay.axaml.cs
@@ -1,5 +1,5 @@
 using Avalonia.Controls;
-using AvatarExplorer.UI.ViewModels;
+using AvatarExplorer.UI.Services;
 
 namespace AvatarExplorer.UI.Views.Overlays;
 
@@ -8,6 +8,6 @@ public partial class ResolveTempAvatarOverlay : UserControl
     public ResolveTempAvatarOverlay()
     {
         InitializeComponent();
-        DataContext = MainWindowViewModel.Instance.ResolveTempAvatarVM;
+        DataContext = InstanceRepository.MainWindow.ResolveTempAvatarVM;
     }
 }

--- a/AvatarExplorer.UI/Views/Overlays/SelectAvatarsOverlay.axaml.cs
+++ b/AvatarExplorer.UI/Views/Overlays/SelectAvatarsOverlay.axaml.cs
@@ -1,5 +1,5 @@
 using Avalonia.Controls;
-using AvatarExplorer.UI.ViewModels;
+using AvatarExplorer.UI.Services;
 
 namespace AvatarExplorer.UI.Views.Overlays;
 
@@ -8,6 +8,6 @@ public partial class SelectAvatarsOverlay : UserControl
     public SelectAvatarsOverlay()
     {
         InitializeComponent();
-        DataContext = MainWindowViewModel.Instance.SelectAvatarsVM;
+        DataContext = InstanceRepository.MainWindow.SelectAvatarsVM;
     }
 }

--- a/AvatarExplorer.UI/Views/Overlays/SettingsOverlay.axaml.cs
+++ b/AvatarExplorer.UI/Views/Overlays/SettingsOverlay.axaml.cs
@@ -1,7 +1,7 @@
 using Avalonia.Controls;
 using Avalonia.Threading;
 using AvatarExplorer.UI.Localization;
-using AvatarExplorer.UI.ViewModels;
+using AvatarExplorer.UI.Services;
 
 namespace AvatarExplorer.UI.Views.Overlays;
 
@@ -10,7 +10,7 @@ public partial class SettingsOverlay : UserControl
     public SettingsOverlay()
     {
         InitializeComponent();
-        DataContext = MainWindowViewModel.Instance.SettingsVM;
+        DataContext = InstanceRepository.MainWindow.SettingsVM;
         Localizer.Instance.LanguageChanged += OnLanguageChanged;
     }
 

--- a/AvatarExplorer.UI/Views/Overlays/TagEditorDialog.axaml.cs
+++ b/AvatarExplorer.UI/Views/Overlays/TagEditorDialog.axaml.cs
@@ -1,5 +1,5 @@
 using Avalonia.Controls;
-using AvatarExplorer.UI.ViewModels;
+using AvatarExplorer.UI.Services;
 
 namespace AvatarExplorer.UI.Views.Overlays;
 
@@ -8,6 +8,6 @@ public partial class TagEditorDialog : UserControl
     public TagEditorDialog()
     {
         InitializeComponent();
-        DataContext = MainWindowViewModel.Instance.TagEditorVM;
+        DataContext = InstanceRepository.MainWindow.TagEditorVM;
     }
 }

--- a/AvatarExplorer.UI/Views/Overlays/TextDialog.axaml.cs
+++ b/AvatarExplorer.UI/Views/Overlays/TextDialog.axaml.cs
@@ -1,5 +1,5 @@
 using Avalonia.Controls;
-using AvatarExplorer.UI.ViewModels;
+using AvatarExplorer.UI.Services;
 
 namespace AvatarExplorer.UI.Views.Overlays;
 
@@ -8,6 +8,6 @@ public partial class TextDialogOverlay : UserControl
     public TextDialogOverlay()
     {
         InitializeComponent();
-        DataContext = MainWindowViewModel.Instance.TextDialogVM;
+        DataContext = InstanceRepository.MainWindow.TextDialogVM;
     }
 }

--- a/AvatarExplorer.UI/Views/Overlays/UnitypackageViewerOverlay.axaml.cs
+++ b/AvatarExplorer.UI/Views/Overlays/UnitypackageViewerOverlay.axaml.cs
@@ -1,5 +1,5 @@
 using Avalonia.Controls;
-using AvatarExplorer.UI.ViewModels;
+using AvatarExplorer.UI.Services;
 
 namespace AvatarExplorer.UI.Views.Overlays;
 
@@ -8,6 +8,6 @@ public partial class UnitypackageViewerOverlay : UserControl
     public UnitypackageViewerOverlay()
     {
         InitializeComponent();
-        DataContext = MainWindowViewModel.Instance.UnitypackageViewerVM;
+        DataContext = InstanceRepository.MainWindow.UnitypackageViewerVM;
     }
 }

--- a/AvatarExplorer.UI/Views/Overlays/UpdateOverlay.axaml.cs
+++ b/AvatarExplorer.UI/Views/Overlays/UpdateOverlay.axaml.cs
@@ -1,5 +1,5 @@
 using Avalonia.Controls;
-using AvatarExplorer.UI.ViewModels;
+using AvatarExplorer.UI.Services;
 
 namespace AvatarExplorer.UI.Views.Overlays;
 
@@ -8,6 +8,6 @@ public partial class UpdateDialogOverlay : UserControl
     public UpdateDialogOverlay()
     {
         InitializeComponent();
-        DataContext = MainWindowViewModel.Instance.UpdateDialogVM;
+        DataContext = InstanceRepository.MainWindow.UpdateDialogVM;
     }
 }

--- a/AvatarExplorer.UI/Views/Overlays/YesNoDialog.axaml.cs
+++ b/AvatarExplorer.UI/Views/Overlays/YesNoDialog.axaml.cs
@@ -1,5 +1,5 @@
 using Avalonia.Controls;
-using AvatarExplorer.UI.ViewModels;
+using AvatarExplorer.UI.Services;
 
 namespace AvatarExplorer.UI.Views.Overlays;
 
@@ -8,6 +8,6 @@ public partial class YesNoDialogOverlay : UserControl
     public YesNoDialogOverlay()
     {
         InitializeComponent();
-        DataContext = MainWindowViewModel.Instance.YesNoDialogVM;
+        DataContext = InstanceRepository.MainWindow.YesNoDialogVM;
     }
 }

--- a/AvatarExplorer.UI/Views/Panels/SidePanel/AdvancedSearch.axaml.cs
+++ b/AvatarExplorer.UI/Views/Panels/SidePanel/AdvancedSearch.axaml.cs
@@ -1,5 +1,5 @@
 using Avalonia.Controls;
-using AvatarExplorer.UI.ViewModels;
+using AvatarExplorer.UI.Services;
 
 namespace AvatarExplorer.UI.Views.Panels;
 
@@ -8,6 +8,6 @@ public partial class AdvancedSearch : UserControl
     public AdvancedSearch()
     {
         InitializeComponent();
-        DataContext = MainViewModel.Instance.AdvancedSearchVM;
+        DataContext = InstanceRepository.MainView.AdvancedSearchVM;
     }
 }

--- a/AvatarExplorer.UI/Views/Panels/SidePanel/BulkImport.axaml.cs
+++ b/AvatarExplorer.UI/Views/Panels/SidePanel/BulkImport.axaml.cs
@@ -4,7 +4,7 @@ using System;
 using System.Linq;
 using Avalonia.Platform.Storage;
 using AvatarExplorer.UI.ViewModels.Panels;
-using AvatarExplorer.UI.ViewModels;
+using AvatarExplorer.UI.Services;
 
 namespace AvatarExplorer.UI.Views.Panels;
 
@@ -13,7 +13,7 @@ public partial class BulkImport : UserControl
     public BulkImport()
     {
         InitializeComponent();
-        DataContext = MainViewModel.Instance.BulkImportVM;
+        DataContext = InstanceRepository.MainView.BulkImportVM;
     }
 
     private void OnDrop(object? sender, DragEventArgs e)

--- a/AvatarExplorer.UI/Views/Panels/SidePanel/BulkImportPreset.axaml.cs
+++ b/AvatarExplorer.UI/Views/Panels/SidePanel/BulkImportPreset.axaml.cs
@@ -1,5 +1,5 @@
 using Avalonia.Controls;
-using AvatarExplorer.UI.ViewModels;
+using AvatarExplorer.UI.Services;
 
 namespace AvatarExplorer.UI.Views.Panels;
 
@@ -8,6 +8,6 @@ public partial class BulkImportPreset : UserControl
     public BulkImportPreset()
     {
         InitializeComponent();
-        DataContext = MainViewModel.Instance.BulkImportPresetVM;
+        DataContext = InstanceRepository.MainView.BulkImportPresetVM;
     }
 }


### PR DESCRIPTION
Introduce InstanceRepository as the single access point for app
singletons (repositories, navigation services, MainWindow/MainView
VMs) and route all ViewModels and Views through it. Extract
notification display from MainWindowViewModel into NotificationManager,
replace inline ReactiveCommand.Create lambdas with named methods, and
drop the TopLevel parameter from LauncherService/StorageService in
favor of TopLevelProvider. No behavioral changes.