### PR TITLE
ci(opencode): switch review model to deepseek-v4-flash

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -31,7 +31,7 @@ jobs:
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
         with:
-          model: opencode-go/qwen3.7-plus
+          model: opencode-go/deepseek-v4-flash
           prompt: |
             Review this pull request and provide feedback.
             Reference the following files for guidelines:


### PR DESCRIPTION
update repository owner review model from qwen3.7-plus to deepseek-v4-flash and fix missing newline at EOF