### PR TITLE
feat(unitypackage): add setting to toggle automatic path rewriting on import

### DIFF
--- a/AvatarExplorer.Core/Data/Localization/en-US.json
+++ b/AvatarExplorer.Core/Data/Localization/en-US.json
@@ -310,6 +310,8 @@
     "Settings.ThumbnailCompressionMaxSize.Description": "Maximum edge size (px) for compression, applied to newly generated images",
 
     "Settings.Item": "Item",
+    "Settings.AutoChangeUnitypackagePath.Title": "Auto Change Unitypackage Path",
+    "Settings.AutoChangeUnitypackagePath.Description": "When importing a Unitypackage, automatically changes the asset destination to \"Assets/{Category}/Original Path\". Only paths under \"Assets\" are affected. Multiple Unitypackages can also be merged into one. You can also import normally from the right-click menu",
     "Settings.RemoveOriginal.Title": "Delete Original File on Import",
     "Settings.RemoveOriginal.Description": "Whether to automatically delete the original file when importing an item",
     "Settings.LinkToOriginal.Title": "Use Folder As-Is",

--- a/AvatarExplorer.Core/Data/Localization/es-ES.json
+++ b/AvatarExplorer.Core/Data/Localization/es-ES.json
@@ -310,6 +310,8 @@
     "Settings.ThumbnailCompressionMaxSize.Description": "Tamaño máximo de borde (px) para compresión, aplicado a las imágenes recién generadas",
 
     "Settings.Item": "Elemento",
+    "Settings.AutoChangeUnitypackagePath.Title": "Cambiar auto. ruta del Unitypackage",
+    "Settings.AutoChangeUnitypackagePath.Description": "Al importar un Unitypackage, cambia automáticamente la ubicación de los assets a \"Assets/{Categoría}/Ruta original\". Solo se modifican las rutas bajo \"Assets\". También se pueden fusionar varios Unitypackages en uno. También puedes importar normalmente desde el menú contextual",
     "Settings.RemoveOriginal.Title": "Eliminar archivo original al importar",
     "Settings.RemoveOriginal.Description": "Si eliminar automáticamente el archivo original al importar un elemento",
     "Settings.LinkToOriginal.Title": "Usar carpeta tal cual",

--- a/AvatarExplorer.Core/Data/Localization/fr-FR.json
+++ b/AvatarExplorer.Core/Data/Localization/fr-FR.json
@@ -310,6 +310,8 @@
     "Settings.ThumbnailCompressionMaxSize.Description": "Taille maximale de bord (px) pour la compression, appliquée aux images nouvellement générées",
 
     "Settings.Item": "Élément",
+    "Settings.AutoChangeUnitypackagePath.Title": "Changer auto. le chemin Unitypackage",
+    "Settings.AutoChangeUnitypackagePath.Description": "Lors de l'importation d'un Unitypackage, modifie automatiquement la destination des assets en \"Assets/{Catégorie}/Chemin d'origine\". Seuls les chemins sous \"Assets\" sont concernés. Plusieurs Unitypackages peuvent également être fusionnés en un seul. Vous pouvez aussi importer normalement depuis le menu contextuel",
     "Settings.RemoveOriginal.Title": "Supprimer le fichier d'origine à l'importation",
     "Settings.RemoveOriginal.Description": "Supprimer automatiquement le fichier d'origine lors de l'importation d'un élément",
     "Settings.LinkToOriginal.Title": "Utiliser le dossier tel quel",

--- a/AvatarExplorer.Core/Data/Localization/ja-JP.json
+++ b/AvatarExplorer.Core/Data/Localization/ja-JP.json
@@ -310,6 +310,8 @@
     "Settings.ThumbnailCompressionMaxSize.Description": "新しく生成する画像に適用される、最大辺の圧縮サイズ(px)です",
 
     "Settings.Item": "アイテム",
+    "Settings.AutoChangeUnitypackagePath.Title": "Unitypackageのパスを自動で変更する",
+    "Settings.AutoChangeUnitypackagePath.Description": "Unitypackageのインポート時、アセットの配置先を\"Assets/{カテゴリ名}/元のパス\"に自動で変更します。\"Assets\"以下のパスのみが対象です。複数のUnitypackageを1つにまとめることも可能です。右クリックメニューからは通常通りインポートすることもできます",
     "Settings.RemoveOriginal.Title": "インポート時に元ファイルを削除する",
     "Settings.RemoveOriginal.Description": "アイテムをインポートした時に、元ファイルを自動で削除するかどうかの設定です",
     "Settings.LinkToOriginal.Title": "フォルダをそのまま使用する",

--- a/AvatarExplorer.Core/Data/Localization/ko-KR.json
+++ b/AvatarExplorer.Core/Data/Localization/ko-KR.json
@@ -310,6 +310,8 @@
     "Settings.ThumbnailCompressionMaxSize.Description": "새로 생성하는 이미지에 적용되는 최대 변 길이(px)입니다",
 
     "Settings.Item": "아이템",
+    "Settings.AutoChangeUnitypackagePath.Title": "Unitypackage 경로 자동 변경",
+    "Settings.AutoChangeUnitypackagePath.Description": "Unitypackage 가져오기 시, 에셋의 배치 경로를 \"Assets/{카테고리명}/원본 경로\"로 자동 변경합니다. \"Assets\" 아래의 경로만 대상입니다. 여러 Unitypackage를 하나로 합칠 수도 있습니다. 우클릭 메뉴에서 평소대로 가져올 수도 있습니다",
     "Settings.RemoveOriginal.Title": "가져오기 시 원본 파일 삭제",
     "Settings.RemoveOriginal.Description": "아이템을 가져올 때 원본 파일을 자동으로 삭제할지 여부를 설정합니다",
     "Settings.LinkToOriginal.Title": "폴더를 그대로 사용",

--- a/AvatarExplorer.Core/Data/Localization/zh-CN.json
+++ b/AvatarExplorer.Core/Data/Localization/zh-CN.json
@@ -310,6 +310,8 @@
     "Settings.ThumbnailCompressionMaxSize.Description": "应用于新生成图像的最大边长压缩尺寸(px)",
 
     "Settings.Item": "项目",
+    "Settings.AutoChangeUnitypackagePath.Title": "自动更改Unitypackage路径",
+    "Settings.AutoChangeUnitypackagePath.Description": "导入Unitypackage时，自动将资产的放置路径更改为\"Assets/{分类名}/原始路径\"。仅\"Assets\"下的路径会被修改。多个Unitypackage也可以合并为一个。也可以从右键菜单正常导入",
     "Settings.RemoveOriginal.Title": "导入时删除原始文件",
     "Settings.RemoveOriginal.Description": "导入项目时是否自动删除原始文件",
     "Settings.LinkToOriginal.Title": "直接使用文件夹",

--- a/AvatarExplorer.Core/Data/Localization/zh-TW.json
+++ b/AvatarExplorer.Core/Data/Localization/zh-TW.json
@@ -310,6 +310,8 @@
     "Settings.ThumbnailCompressionMaxSize.Description": "套用於新產生圖片的最大邊長壓縮尺寸(px)",
 
     "Settings.Item": "項目",
+    "Settings.AutoChangeUnitypackagePath.Title": "自動變更Unitypackage路徑",
+    "Settings.AutoChangeUnitypackagePath.Description": "匯入Unitypackage時，自動將資產的放置路徑變更為\"Assets/{分類名}/原始路徑\"。僅\"Assets\"下的路徑會被修改。多個Unitypackage也可以合併為一個。也可以從右鍵選單正常匯入",
     "Settings.RemoveOriginal.Title": "匯入時刪除原始檔案",
     "Settings.RemoveOriginal.Description": "匯入項目時是否自動刪除原始檔案",
     "Settings.LinkToOriginal.Title": "直接使用資料夾",

--- a/AvatarExplorer.Core/Localization/LocalizationKeys.g.cs
+++ b/AvatarExplorer.Core/Localization/LocalizationKeys.g.cs
@@ -507,6 +507,11 @@ public static class Loc
             public const string Description = "Settings.ThumbnailCompressionMaxSize.Description";
         }
         public const string Item = "Settings.Item";
+        public static class AutoChangeUnitypackagePath
+        {
+            public const string Title = "Settings.AutoChangeUnitypackagePath.Title";
+            public const string Description = "Settings.AutoChangeUnitypackagePath.Description";
+        }
         public static class RemoveOriginal
         {
             public const string Title = "Settings.RemoveOriginal.Title";

--- a/AvatarExplorer.Core/Models/System/RuntimeSettings.cs
+++ b/AvatarExplorer.Core/Models/System/RuntimeSettings.cs
@@ -12,6 +12,7 @@ public record RuntimeSettings
     public int AutoBackupInterval { get; init; } = 5;
     public bool TreatEmptySupportedAvatarAsNone { get; init; } = false;
     public int MaxDegreeOfParallelism { get; init; } = 4;
+    public bool AutoChangeUnitypackagePath { get; init; } = true;
     public bool CheckForUpdate { get; init; } = true;
     public UpdateChannel UpdateChannel { get; init; } = UpdateChannel.Stable;
 }

--- a/AvatarExplorer.Core/Services/IO/FileSystemService.cs
+++ b/AvatarExplorer.Core/Services/IO/FileSystemService.cs
@@ -39,11 +39,12 @@ public record ExtractResult
 
 public class ModifiedUnitypackagesResult
 {
-    public bool IsError { get; set; } = true;
+    public bool IsError { get; set; } = false;
     public string? ModifiedUnitypackagePath { get; set; } = null;
     public List<string> Success { get; } = [];
     public List<string> Failed { get; } = [];
     public bool ContainsScripts { get; set; }
+    public bool IsNotModified { get; set; } = false;
 }
 
 public class ItemPathEntry
@@ -216,9 +217,19 @@ public static class FileSystemService
         return separatorIndex >= 0 ? normalizedEntryName[..separatorIndex] : normalizedEntryName;
     }
 
-    public static async Task<ModifiedUnitypackagesResult> ModifyUnitypackageFilePathsAsync(IReadOnlyList<UnitypackageImportEntry> entries, Func<(string, int), Task>? reportProgress = null)
+    public static async Task<ModifiedUnitypackagesResult> ModifyUnitypackageFilePathsAsync(IReadOnlyList<UnitypackageImportEntry> entries, bool? changeUnitypackagePath = null, Func<(string, int), Task>? reportProgress = null)
     {
         var result = new ModifiedUnitypackagesResult();
+
+        changeUnitypackagePath ??= AvatarExplorerApp.Instance.RuntimeSettings.AutoChangeUnitypackagePath;
+        if (entries.Count == 1 && !changeUnitypackagePath.Value)
+        {
+            // 処理したとしても元のUnitypackageと同じのため、そのまま返してあげる
+            result.ModifiedUnitypackagePath = entries[0].FilePath;
+            result.Success.Add(entries[0].FilePath);
+            result.IsNotModified = true;
+            return result;
+        }
 
         try
         {
@@ -249,7 +260,7 @@ public static class FileSystemService
             {
                 try
                 {
-                    var (ProcessedEntries, ContainsScripts) = await ExtractUnitypackageToFolderAsync(entry.FilePath, saveFolderPath, entry.CategoryDisplayName, totalEntries, currentProcessedEntries, reportProgress);
+                    var (ProcessedEntries, ContainsScripts) = await ExtractUnitypackageToFolderAsync(entry.FilePath, saveFolderPath, entry.CategoryDisplayName, changeUnitypackagePath.Value, totalEntries, currentProcessedEntries, reportProgress);
                     currentProcessedEntries = ProcessedEntries;
                     if (ContainsScripts) result.ContainsScripts = true;
                     result.Success.Add(entry.FilePath);
@@ -272,9 +283,7 @@ public static class FileSystemService
 
             if (File.Exists(unitypackagePath))
             {
-                result.IsError = false;
                 result.ModifiedUnitypackagePath = unitypackagePath;
-
                 return result;
             }
 
@@ -309,7 +318,7 @@ public static class FileSystemService
         await TarGzReader(tarGzFilePath, _ => count++);
         return count;
     }
-    private static async Task<(int ProcessedEntries, bool ContainsScripts)> ExtractUnitypackageToFolderAsync(string tarGzFilePath, string saveFilePath, string category, int totalEntries, int currentProcessedEntries = 0, Func<(string, int), Task>? reportProgress = null)
+    private static async Task<(int ProcessedEntries, bool ContainsScripts)> ExtractUnitypackageToFolderAsync(string tarGzFilePath, string saveFilePath, string category, bool changeUnitypackagePath, int totalEntries, int currentProcessedEntries = 0, Func<(string, int), Task>? reportProgress = null)
     {
         int processedEntries = currentProcessedEntries;
         bool containsScripts = false;
@@ -320,7 +329,7 @@ public static class FileSystemService
         {
             try
             {
-                if (Path.GetFileName(entry.Name) == "pathname" && entry.DataStream != null)
+                if (changeUnitypackagePath && Path.GetFileName(entry.Name) == "pathname" && entry.DataStream != null)
                 {
                     using StreamReader reader = new(entry.DataStream);
                     string assetPath = await reader.ReadToEndAsync();

--- a/AvatarExplorer.UI/Services/External/UnitypackageService.cs
+++ b/AvatarExplorer.UI/Services/External/UnitypackageService.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -31,7 +30,7 @@ internal static class UnitypackageService
             });
         }
 
-        var result = await FileSystemService.ModifyUnitypackageFilePathsAsync(entries, progressAction);
+        var result = await FileSystemService.ModifyUnitypackageFilePathsAsync(entries, reportProgress: progressAction);
         return result;
     }
 
@@ -64,6 +63,12 @@ internal static class UnitypackageService
         IReadOnlyList<UnitypackageImportEntry> entries,
         string errorKey = Loc.Error.ImportUnitypackageFailed)
     {
+        if (entries.Count == 1 && !InstanceRepository.RuntimeSettings.AutoChangeUnitypackagePath)
+        {
+            await OpenModifiedUnitypackage(entries[0].FilePath);
+            return;
+        }
+
         ModifiedUnitypackagesResult? importResult = null;
 
         await NotificationManager.ShowWithProgress(

--- a/AvatarExplorer.UI/ViewModels/Overlays/SettingsViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/SettingsViewModel.cs
@@ -45,6 +45,7 @@ public class SettingsViewModel : ViewModelBase, IInitializable
     [Reactive] public string ItemsPerPage { get; set; } = string.Empty;
     [Reactive] public int SelectedViewMode { get; set; }
     [Reactive] public int SelectedGridItemSize { get; set; }
+    [Reactive] public bool AutoChangeUnitypackagePath { get; set; }
     [Reactive] public bool RemoveOriginal { get; set; }
     [Reactive] public bool LinkToOriginal { get; set; }
     [Reactive] public bool TreatEmptySupportedAvatarAsNone { get; set; }
@@ -150,6 +151,7 @@ public class SettingsViewModel : ViewModelBase, IInitializable
         HoverIconSize = preferences.HoverIconSize;
         SelectedAntiAliasing = (int)preferences.AntiAliasingMode;
         ItemsPerPage = preferences.ItemsPerPage.ToString();
+        AutoChangeUnitypackagePath = runtimeSettings.AutoChangeUnitypackagePath;
         RemoveOriginal = runtimeSettings.RemoveOriginal;
         LinkToOriginal = runtimeSettings.ShouldLinkToOriginal;
         TreatEmptySupportedAvatarAsNone = runtimeSettings.TreatEmptySupportedAvatarAsNone;
@@ -446,6 +448,7 @@ public class SettingsViewModel : ViewModelBase, IInitializable
             AutoBackupInterval = ValueParser.Int(AutoBackupInterval, 5),
             TreatEmptySupportedAvatarAsNone = TreatEmptySupportedAvatarAsNone,
             MaxDegreeOfParallelism = ValueParser.Int(MaxDegreeOfParallelism, 4),
+            AutoChangeUnitypackagePath = AutoChangeUnitypackagePath,
             CheckForUpdate = CheckForUpdate,
             UpdateChannel = (UpdateChannel)SelectedUpdateChannel
         };

--- a/AvatarExplorer.UI/Views/Overlays/SettingsOverlay.axaml
+++ b/AvatarExplorer.UI/Views/Overlays/SettingsOverlay.axaml
@@ -237,6 +237,17 @@
                                 <StackPanel Spacing="20" Margin="0,0,10,0">
                                     <Grid ColumnDefinitions="*,*" ColumnSpacing="10">
                                         <Grid Grid.Column="0" RowDefinitions="Auto,*" RowSpacing="5">
+                                            <TextBlock Classes="settingslabel title" Grid.Row="0" Text="{Binding [Settings.AutoChangeUnitypackagePath.Title], Source={x:Static loc:Localizer.Instance}}"/>
+                                            <TextBlock Classes="settingslabel description" Grid.Row="1" Text="{Binding [Settings.AutoChangeUnitypackagePath.Description], Source={x:Static loc:Localizer.Instance}}"/>
+                                        </Grid>
+
+                                        <Grid Grid.Column="1" ColumnDefinitions="*,Auto" ColumnSpacing="5">
+                                            <ToggleSwitch IsChecked="{Binding AutoChangeUnitypackagePath}" Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Right"/>
+                                        </Grid>
+                                    </Grid>
+
+                                    <Grid ColumnDefinitions="*,*" ColumnSpacing="10">
+                                        <Grid Grid.Column="0" RowDefinitions="Auto,*" RowSpacing="5">
                                             <TextBlock Classes="settingslabel title" Grid.Row="0" Text="{Binding [Settings.RemoveOriginal.Title], Source={x:Static loc:Localizer.Instance}}"/>
                                             <TextBlock Classes="settingslabel description" Grid.Row="1" Text="{Binding [Settings.RemoveOriginal.Description], Source={x:Static loc:Localizer.Instance}}"/>
                                         </Grid>


### PR DESCRIPTION
add RuntimeSettings.AutoChangeUnitypackagePath (default true) to allow users to control whether asset destinations are rewritten to "Assets/{Category}/Original Path" on unitypackage import.

- update FileSystemService.ModifyUnitypackageFilePathsAsync to accept changeUnitypackagePath parameter, early-return original path with IsNotModified=true and Success tracking when single import with toggle off, and fix IsError default value
- bypass progress notification in UnitypackageService.ImportWithProgress for single unmodified imports to prevent notification flicker
- add toggle binding in SettingsViewModel and SettingsOverlay
- add localization keys for 7 languages and regenerate LocalizationKeys.g.cs