### PR TITLE
docs: clarify navigation and item management API documentation

### DIFF
--- a/docs/02-navigation-system.md
+++ b/docs/02-navigation-system.md
@@ -76,7 +76,7 @@ Identifierを指定して選択を行います。
 navigation.Select("avatar:item:e10abf3d-cca7-4117-a5e9-52926a4f8990");
 
 // カテゴリを選択
-navigation.Select("type:2"); // Clothing
+navigation.Select("type:2"); // = new ItemCategory(ItemType.Clothing).Identifier
 
 // アイテムを選択
 navigation.Select("item:91517db1-eaf3-4137-914f-551cf3669692");
@@ -85,7 +85,7 @@ navigation.Select("item:91517db1-eaf3-4137-914f-551cf3669692");
 navigation.Select("folder:850F5169");
 
 // 拡張子を選択
-navigation.Select("extension:3"); // .unitypackage
+navigation.Select("extension:2"); // .unitypackage (数字の部分は、(int)ItemFileCategoryType.Unitypackageと同じです)
 
 // ファイルを選択（イベントが発火）
 navigation.Select("file:a1b2c3d4...");
@@ -94,6 +94,8 @@ navigation.Select("file:a1b2c3d4...");
 ### Select()の戻り値
 
 `Select()`は`Guid?`を返します。ファイル選択の場合は`null`が返ります。
+
+この`Guid`は、AvatarExplorer.UIではナビゲーション時のページやスクロール位置の保存に使用されています。
 
 ```csharp
 var result = navigation.Select("item:xxxxx");

--- a/docs/03-item-management.md
+++ b/docs/03-item-management.md
@@ -236,14 +236,19 @@ var paths = new List<ItemPathEntry>
 var result = await itemRepo.AddPaths(
     "item:xxxxx",
     paths,
-    shouldLinkToOriginal: false,  // true: 元ファイルへのリンク、false: コピー
-    removeOriginal: true          // true: 元のファイルを削除
+    shouldLinkToOriginal: false,  // true: フォルダだった場合は元フォルダへリンク、false: コピー
+    removeOriginal: true          // true: アーカイブだった場合は展開後に元のファイルを削除
 );
 
 if (!result.IsError)
 {
     Console.WriteLine("パスの追加成功");
+
+    // アーカイブ展開 or フォルダコピーが発生した場合にパスが設定される
     Console.WriteLine($"展開先: {result.Value.ItemParentFolder}");
+
+    // shouldLinkToOriginalがtrueで、パスがフォルダーだった場合はここに入ります
+    Console.WriteLine($"展開されずにそのまま追加されたフォルダー: {string.Join(", ", result.Value.FolderPaths)}");
 }
 ```
 
@@ -373,7 +378,11 @@ foreach (var file in results)
 
 データベースの整合性を保つために、ItemTypeを自動修正します。
 
+> [!WARNING]
+> CoreのVersionがv2.8.0より前は、カスタムカテゴリが移行されずに破壊されます。最新のmainブランチでは修正されています。
+
 ```csharp
+// avatarExist: ユーザーがアバターを追加したことがあるかどうか（= ItemTypeが壊れていないかの判定に使用）
 itemRepo.ValidateAndAutoFixItemType(avatarExist: true);
 ```
 


### PR DESCRIPTION
- Added clarifying comments for navigation.Select() examples

- Fixed incorrect extension number for .unitypackage (3→2)

- Improved parameter comments for AddPaths()

- Added warning about Core version v2.8.0 and custom category migration