### PR TITLE
fix(ui): flip HoverThumbnailWindow upward when cursor is in lower half of screen

### DIFF
--- a/AvatarExplorer.UI/Views/MainView.axaml.cs
+++ b/AvatarExplorer.UI/Views/MainView.axaml.cs
@@ -14,6 +14,7 @@ using AvatarExplorer.Core.Extensions;
 using AvatarExplorer.Core.Utils;
 using AvatarExplorer.UI.Extensions;
 using AvatarExplorer.UI.Services;
+using AvatarExplorer.UI.Services.System;
 using AvatarExplorer.UI.Services.Utilities;
 using AvatarExplorer.UI.Services.ViewControl;
 using AvatarExplorer.UI.ViewModels;
@@ -325,10 +326,19 @@ public partial class MainView : UserControl
 
     private PixelPoint GetScreenPosition(PointerEventArgs e)
     {
-        var topLevel = TopLevel.GetTopLevel(this);
-        if (topLevel is not Window window) return default;
+        if (TopLevelProvider.Current is not Window window) return default;
         var position = window.PointToScreen(e.GetPosition(window));
-        return new PixelPoint(position.X + HoverOffset, position.Y + HoverOffset);
+
+        var screen = window.Screens?.ScreenFromPoint(position);
+        if (screen is null) return new PixelPoint(position.X + HoverOffset, position.Y + HoverOffset);
+
+        var workingArea = screen.WorkingArea;
+        var size = (int)(InstanceRepository.UserPreferences.HoverIconSize * screen.Scaling);
+        var y = position.Y > workingArea.Y + workingArea.Height / 2
+            ? Math.Max(workingArea.Y, position.Y - size - HoverOffset)
+            : position.Y + HoverOffset;
+
+        return new PixelPoint(position.X + HoverOffset, y);
     }
 
     private async void OnItemButtonPointerPressed(object? sender, PointerPressedEventArgs e)

--- a/AvatarExplorer.UI/Views/MainView.axaml.cs
+++ b/AvatarExplorer.UI/Views/MainView.axaml.cs
@@ -324,7 +324,7 @@ public partial class MainView : UserControl
         vm.UpdateHoverThumbnailPosition(GetScreenPosition(e));
     }
 
-    private PixelPoint GetScreenPosition(PointerEventArgs e)
+    private static PixelPoint GetScreenPosition(PointerEventArgs e)
     {
         if (TopLevelProvider.Current is not Window window) return default;
         var position = window.PointToScreen(e.GetPosition(window));

--- a/AvatarExplorer.UI/Views/MainView.axaml.cs
+++ b/AvatarExplorer.UI/Views/MainView.axaml.cs
@@ -334,7 +334,7 @@ public partial class MainView : UserControl
 
         var workingArea = screen.WorkingArea;
         var size = (int)(InstanceRepository.UserPreferences.HoverIconSize * screen.Scaling);
-        var y = position.Y > workingArea.Y + workingArea.Height / 2
+        var y = position.Y > workingArea.Y + (workingArea.Height / 2)
             ? Math.Max(workingArea.Y, position.Y - size - HoverOffset)
             : position.Y + HoverOffset;
 


### PR DESCRIPTION
Prevents the hover thumbnail from being cut off at the bottom edge of the screen. Uses Screens.ScreenFromPoint to detect the active monitor's working area, and positions the window above the cursor when the cursor is in the lower half. Also clamps the Y position and uses physical pixel scaling for DPI-correct placement.

Fixes #788 