### PR TITLE
fix(ui): move KeyDown handling to MainWindow to fix events not being received

### DIFF
--- a/AvatarExplorer.UI/ViewModels/MainWindowViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/MainWindowViewModel.cs
@@ -1,8 +1,10 @@
 using System;
 using System.IO;
+using System.Reactive.Linq;
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls.Notifications;
+using Avalonia.Input;
 using Avalonia.Media;
 using Avalonia.Media.Imaging;
 using Avalonia.Styling;
@@ -23,6 +25,7 @@ using AvatarExplorer.UI.Utils;
 using AvatarExplorer.UI.ViewModels.Overlays;
 using ReactiveUI.Fody.Helpers;
 using AvatarExplorer.UI.Services.Utilities;
+using ReactiveUI;
 
 namespace AvatarExplorer.UI.ViewModels;
 
@@ -32,6 +35,7 @@ public class MainWindowViewModel : ViewModelBase, IInitializable, IPostInitializ
     [Reactive] public ImageBrush? BackgroundImage { get; set; } = null;
     [Reactive] public IBrush? Background { get; set; } = null;
     [Reactive] public FontFamily FontFamily { get; set; } = FontUtils.GetFontFamily(null);
+    [Reactive] public bool IsAnyOverlayVisible { get; set; }
 
     public static MainWindowViewModel Instance { get; private set; } = null!;
     public string? LastDragDropPath { get; set; } = null;
@@ -75,6 +79,7 @@ public class MainWindowViewModel : ViewModelBase, IInitializable, IPostInitializ
     [Reactive] public bool IsArchivePasswordDialogVisible { get; set; }
 
     public event Action? WindowClosing;
+    public event Action<KeyEventArgs>? KeyDown;
 
     public string[] ApplicationArgs { get; private set; } = [];
 
@@ -88,6 +93,8 @@ public class MainWindowViewModel : ViewModelBase, IInitializable, IPostInitializ
 
     public async Task Initialize()
     {
+        InitializeObservable();
+
         AppInitializer.InitializeApp();
         AppInitializer.InitializeLocalization(Path.Combine(AppContext.BaseDirectory, "locales"));
         AppInitializer.InitializeContextMenu();
@@ -108,6 +115,37 @@ public class MainWindowViewModel : ViewModelBase, IInitializable, IPostInitializ
         ApplyPreferenceSettings(InstanceRepository.UserPreferences);
         UpdateFontFamily();
         UpdateWindowTitle();
+    }
+    private void InitializeObservable()
+    {
+        var overlayVisibilityChanges = new[]
+        {
+            this.WhenAnyValue(x => x.SettingsVM.IsVisible),
+            this.WhenAnyValue(x => x.ItemEditorVM.IsVisible),
+            this.WhenAnyValue(x => x.SelectAvatarsVisible),
+            this.WhenAnyValue(x => x.ResolveTempAvatarVM.IsVisible),
+            this.WhenAnyValue(x => x.EditCommonAvatarsVM.IsVisible),
+            this.WhenAnyValue(x => x.IsEditMemoVisible),
+            this.WhenAnyValue(x => x.IsEditTagsVisible),
+            this.WhenAnyValue(x => x.ImportDataVM.IsVisible),
+            this.WhenAnyValue(x => x.ResetDatabaseVM.IsVisible),
+            this.WhenAnyValue(x => x.ExportDataVM.IsVisible),
+            this.WhenAnyValue(x => x.FetchAllThumbnailsVM.IsVisible),
+            this.WhenAnyValue(x => x.FetchAllVariationHashesVM.IsVisible),
+            this.WhenAnyValue(x => x.UnitypackageViewerVM.IsVisible),
+            this.WhenAnyValue(x => x.PdfViewerVM.IsVisible),
+            this.WhenAnyValue(x => x.IsTextDialogVisible),
+            this.WhenAnyValue(x => x.IsArchivePasswordDialogVisible),
+            this.WhenAnyValue(x => x.IsUpdateDialogVisible),
+            this.WhenAnyValue(x => x.MergeCategoryVM.IsVisible),
+            this.WhenAnyValue(x => x.TagEditorVM.IsVisible),
+            this.WhenAnyValue(x => x.IsYesNoDialogVisible),
+            this.WhenAnyValue(x => x.InitialSetupVM.IsVisible),
+            this.WhenAnyValue(x => x.ErrorLogVM.IsVisible)
+        };
+
+        Observable.Merge(overlayVisibilityChanges)
+            .Subscribe(_ => IsAnyOverlayVisible = CheckAnyOverlayVisible());
     }
     public async Task OnInitialized()
     {
@@ -312,5 +350,36 @@ public class MainWindowViewModel : ViewModelBase, IInitializable, IPostInitializ
     {
         WindowClosing?.Invoke();
         AvatarExplorerApp.ClearTemp();
+    }
+
+    public void OnKeyDown(KeyEventArgs e)
+    {
+        KeyDown?.Invoke(e);
+    }
+
+    private bool CheckAnyOverlayVisible()
+    {
+        return SettingsVM.IsVisible
+            || ItemEditorVM.IsVisible
+            || SelectAvatarsVisible
+            || ResolveTempAvatarVM.IsVisible
+            || EditCommonAvatarsVM.IsVisible
+            || IsEditMemoVisible
+            || IsEditTagsVisible
+            || ImportDataVM.IsVisible
+            || ResetDatabaseVM.IsVisible
+            || ExportDataVM.IsVisible
+            || FetchAllThumbnailsVM.IsVisible
+            || FetchAllVariationHashesVM.IsVisible
+            || UnitypackageViewerVM.IsVisible
+            || PdfViewerVM.IsVisible
+            || IsTextDialogVisible
+            || IsArchivePasswordDialogVisible
+            || IsUpdateDialogVisible
+            || MergeCategoryVM.IsVisible
+            || TagEditorVM.IsVisible
+            || IsYesNoDialogVisible
+            || InitialSetupVM.IsVisible
+            || ErrorLogVM.IsVisible;
     }
 }

--- a/AvatarExplorer.UI/Views/MainView.axaml
+++ b/AvatarExplorer.UI/Views/MainView.axaml
@@ -11,8 +11,7 @@
     xmlns:ia="clr-namespace:Avalonia.Xaml.Interactions.Core;assembly=Avalonia.Xaml.Interactions"
     x:Class="AvatarExplorer.UI.Views.MainView"
     x:DataType="vm:MainViewModel"
-    PointerPressed="OnMainPointerPressed"
-    KeyDown="OnKeyDown">
+    PointerPressed="OnMainPointerPressed">
 
     <UserControl.Styles>
         <Style Selector="Button.PathSegment">

--- a/AvatarExplorer.UI/Views/MainView.axaml.cs
+++ b/AvatarExplorer.UI/Views/MainView.axaml.cs
@@ -53,6 +53,24 @@ public partial class MainView : UserControl
         RegisterHoverThumbnailEvent();
         RegisterWindowClosingEvent();
         RegisterGridResizeEvent();
+        RegisterKeyDownEvent();
+    }
+
+    private void RegisterKeyDownEvent()
+    {
+        InstanceRepository.MainWindow.KeyDown += HandleKeyDown;
+    }
+
+    private void HandleKeyDown(KeyEventArgs e)
+    {
+        if (InstanceRepository.MainWindow.IsAnyOverlayVisible) return;
+
+        var controlPressed = (e.KeyModifiers & KeyModifiers.Control) == KeyModifiers.Control;
+        if (controlPressed && e.Key == Key.F)
+        {
+            SearchTextBox.Focus();
+            e.Handled = true;
+        }
     }
 
     private void RegisterGridResizeEvent()
@@ -395,14 +413,6 @@ public partial class MainView : UserControl
         if (sideButtonPressed && DataContext is MainViewModel vm)
         {
             vm.Undo();
-        }
-    }
-    private void OnKeyDown(object? sender, KeyEventArgs e)
-    {
-        var controlPressed = (e.KeyModifiers & KeyModifiers.Control) == KeyModifiers.Control;
-        if (controlPressed && e.Key == Key.F)
-        {
-            SearchTextBox.Focus();
         }
     }
 }

--- a/AvatarExplorer.UI/Views/MainWindow.axaml
+++ b/AvatarExplorer.UI/Views/MainWindow.axaml
@@ -16,7 +16,8 @@
         DragDrop.AllowDrop="True"
         DragDrop.DragOver="OnDragDropOver"
         DragDrop.Drop="OnDragDrop"
-        Closing="OnWindowClosing">
+        Closing="OnWindowClosing"
+        KeyDown="OnKeyDown">
 
     <Window.DataContext>
         <vm:MainWindowViewModel/>

--- a/AvatarExplorer.UI/Views/MainWindow.axaml.cs
+++ b/AvatarExplorer.UI/Views/MainWindow.axaml.cs
@@ -64,4 +64,10 @@ public partial class MainWindow : Window
         if (DataContext is MainWindowViewModel vm)
             vm.OnWindowClosing();
     }
+
+    private void OnKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (DataContext is MainWindowViewModel vm)
+            vm.OnKeyDown(e);
+    }
 }


### PR DESCRIPTION
- Move OnKeyDown from MainView.axaml.cs to MainWindow.axaml.cs
- Add KeyDown event and IsAnyOverlayVisible property to MainWindowViewModel
- MainView subscribes to MainWindowViewModel's KeyDown event
- SearchBox focus (Ctrl+F) only works when no overlay is visible
- Add Esc key handling to unfocus SearchTextBox when focused
- Monitor all overlay visibility states using ReactiveUI WhenAnyValue + Observable.Merge