### PR TITLE
feat(items): add setting to hide avatar category when avatar selected

### DIFF
--- a/AvatarExplorer.Core/Data/Localization/en-US.json
+++ b/AvatarExplorer.Core/Data/Localization/en-US.json
@@ -325,6 +325,8 @@
     "Settings.LinkToOriginal.Description": "When adding a folder, use it directly without copying",
     "Settings.TreatEmptySupportedAvatarAsNone.Title": "Treat Empty Supported Avatars as None",
     "Settings.TreatEmptySupportedAvatarAsNone.Description": "When no supported avatars are configured for an item, treat it as unsupported rather than supported by all avatars.",
+    "Settings.HideAvatarCategoryWhenAvatarSelected.Title": "Hide Avatar Category When Avatar Selected",
+    "Settings.HideAvatarCategoryWhenAvatarSelected.Description": "When selecting items from an avatar, exclude the avatar category from the category list.",
     "Settings.TagEditor.Title": "Edit Tags",
     "Settings.TagEditor.Description": "Edit existing tags",
     "Settings.TagEditor.Open": "Open",

--- a/AvatarExplorer.Core/Data/Localization/es-ES.json
+++ b/AvatarExplorer.Core/Data/Localization/es-ES.json
@@ -325,6 +325,8 @@
     "Settings.LinkToOriginal.Description": "Al agregar una carpeta, usarla directamente sin copiarla",
     "Settings.TreatEmptySupportedAvatarAsNone.Title": "Tratar avatares compatibles vacíos como ninguno",
     "Settings.TreatEmptySupportedAvatarAsNone.Description": "Cuando un elemento no tiene avatares compatibles configurados, tratarlo como no compatible en lugar de compatible con todos los avatares.",
+    "Settings.HideAvatarCategoryWhenAvatarSelected.Title": "Ocultar la categoría de avatar cuando se selecciona un avatar",
+    "Settings.HideAvatarCategoryWhenAvatarSelected.Description": "Al seleccionar elementos desde un avatar, excluya la categoría de avatar de la lista de categorías.",
     "Settings.TagEditor.Title": "Editar etiquetas",
     "Settings.TagEditor.Description": "Editar etiquetas existentes",
     "Settings.TagEditor.Open": "Abrir",

--- a/AvatarExplorer.Core/Data/Localization/fr-FR.json
+++ b/AvatarExplorer.Core/Data/Localization/fr-FR.json
@@ -325,6 +325,8 @@
     "Settings.LinkToOriginal.Description": "Lors de l'ajout d'un dossier, l'utiliser directement sans le copier",
     "Settings.TreatEmptySupportedAvatarAsNone.Title": "Traiter les avatars pris en charge vides comme aucun",
     "Settings.TreatEmptySupportedAvatarAsNone.Description": "Lorsqu'aucun avatar pris en charge n'est configuré pour un élément, le traiter comme non pris en charge plutôt que comme pris en charge par tous les avatars.",
+    "Settings.HideAvatarCategoryWhenAvatarSelected.Title": "Masquer la catégorie d'avatar lorsque un avatar est sélectionné",
+    "Settings.HideAvatarCategoryWhenAvatarSelected.Description": "Lors de la sélection d'éléments à partir d'un avatar, excluez la catégorie d'avatar de la liste des catégories.",
     "Settings.TagEditor.Title": "Éditer les tags",
     "Settings.TagEditor.Description": "Modifier les tags existants",
     "Settings.TagEditor.Open": "Ouvrir",

--- a/AvatarExplorer.Core/Data/Localization/ja-JP.json
+++ b/AvatarExplorer.Core/Data/Localization/ja-JP.json
@@ -325,6 +325,8 @@
     "Settings.LinkToOriginal.Description": "フォルダ追加時、そのフォルダをコピーせずにそのまま使用します",
     "Settings.TreatEmptySupportedAvatarAsNone.Title": "対応アバター未設定を未対応として扱う",
     "Settings.TreatEmptySupportedAvatarAsNone.Description": "アイテムの対応アバターが一つも設定されていない場合、全てのアバターに対応しているのではなく、どのアバターにも対応していないとみなすようになります。",
+    "Settings.HideAvatarCategoryWhenAvatarSelected.Title": "アバター選択時はアバターカテゴリを非表示にする",
+    "Settings.HideAvatarCategoryWhenAvatarSelected.Description": "アバターからアイテムを選択する時、カテゴリ一覧からアバターカテゴリは除外して表示します。",
     "Settings.TagEditor.Title": "タグの編集",
     "Settings.TagEditor.Description": "既存タグの編集ができます",
     "Settings.TagEditor.Open": "開く",

--- a/AvatarExplorer.Core/Data/Localization/ko-KR.json
+++ b/AvatarExplorer.Core/Data/Localization/ko-KR.json
@@ -325,6 +325,8 @@
     "Settings.LinkToOriginal.Description": "폴더를 추가할 때, 복사하지 않고 그대로 사용합니다",
     "Settings.TreatEmptySupportedAvatarAsNone.Title": "대응 아바타 미설정을 미대응으로 처리",
     "Settings.TreatEmptySupportedAvatarAsNone.Description": "아이템에 대응 아바타가 하나도 설정되지 않은 경우, 모든 아바타에 대응하는 것이 아니라 어느 아바타에도 대응하지 않는 것으로 간주합니다.",
+    "Settings.HideAvatarCategoryWhenAvatarSelected.Title": "아바타 선택 시 아바타 카테고리 숨기기",
+    "Settings.HideAvatarCategoryWhenAvatarSelected.Description": "아바타에서 아이템을 선택할 때, 카테고리 목록에서 아바타 카테고리를 제외하여 표시합니다.",
     "Settings.TagEditor.Title": "태그 편집",
     "Settings.TagEditor.Description": "기존 태그를 편집할 수 있습니다",
     "Settings.TagEditor.Open": "열기",

--- a/AvatarExplorer.Core/Data/Localization/zh-CN.json
+++ b/AvatarExplorer.Core/Data/Localization/zh-CN.json
@@ -325,6 +325,8 @@
     "Settings.LinkToOriginal.Description": "添加文件夹时，直接使用该文件夹而不进行复制",
     "Settings.TreatEmptySupportedAvatarAsNone.Title": "将未设置支持头像视为不支持",
     "Settings.TreatEmptySupportedAvatarAsNone.Description": "当项目没有设置任何支持头像时，不将其视为支持所有头像，而是视为不支持任何头像。",
+    "Settings.HideAvatarCategoryWhenAvatarSelected.Title": "选择头像时隐藏头像分类",
+    "Settings.HideAvatarCategoryWhenAvatarSelected.Description": "从头像选择项目时，从分类列表中排除头像分类进行显示。",
     "Settings.TagEditor.Title": "标签编辑",
     "Settings.TagEditor.Description": "可以编辑现有标签",
     "Settings.TagEditor.Open": "打开",

--- a/AvatarExplorer.Core/Data/Localization/zh-TW.json
+++ b/AvatarExplorer.Core/Data/Localization/zh-TW.json
@@ -325,6 +325,8 @@
     "Settings.LinkToOriginal.Description": "當新增資料夾時，直接使用該資料夾而不進行複製",
     "Settings.TreatEmptySupportedAvatarAsNone.Title": "將未設定支援頭像視為不支援",
     "Settings.TreatEmptySupportedAvatarAsNone.Description": "當項目沒有設定任何支援頭像時，不將其視為支援所有頭像，而是視為不支援任何頭像。",
+    "Settings.HideAvatarCategoryWhenAvatarSelected.Title": "選擇頭像時隱藏頭像分類",
+    "Settings.HideAvatarCategoryWhenAvatarSelected.Description": "從頭像選擇項目時，從分類列表中排除頭像分類進行顯示。",
     "Settings.TagEditor.Title": "標籤編輯",
     "Settings.TagEditor.Description": "可以編輯現有標籤",
     "Settings.TagEditor.Open": "開啟",

--- a/AvatarExplorer.Core/Localization/LocalizationKeys.g.cs
+++ b/AvatarExplorer.Core/Localization/LocalizationKeys.g.cs
@@ -540,6 +540,11 @@ public static class Loc
             public const string Title = "Settings.TreatEmptySupportedAvatarAsNone.Title";
             public const string Description = "Settings.TreatEmptySupportedAvatarAsNone.Description";
         }
+        public static class HideAvatarCategoryWhenAvatarSelected
+        {
+            public const string Title = "Settings.HideAvatarCategoryWhenAvatarSelected.Title";
+            public const string Description = "Settings.HideAvatarCategoryWhenAvatarSelected.Description";
+        }
         public static class TagEditor
         {
             public const string Title = "Settings.TagEditor.Title";

--- a/AvatarExplorer.Core/Models/Items/ItemCategory.cs
+++ b/AvatarExplorer.Core/Models/Items/ItemCategory.cs
@@ -11,11 +11,13 @@ public record ItemCategory : IIdentifiable
 {
     /// <summary>組み込みのカテゴリタイプです。カスタムカテゴリの場合は <see cref="ItemType.Custom"/> になります。</summary>
     public ItemType Type { get; init; } = ItemType.None;
+
     /// <summary>カスタムカテゴリ名です。組み込みタイプの場合は空文字になります。</summary>
     public string CustomCategory { get; init; } = string.Empty;
 
     /// <summary>カスタムカテゴリの識別子プレフィックス（"custom:"）です。</summary>
     public const string CustomCategoryPrefix = "custom:";
+
     /// <summary>組み込みタイプカテゴリの識別子プレフィックス（"type:"）です。</summary>
     public const string TypeCategoryPrefix = "type:";
 
@@ -26,6 +28,7 @@ public record ItemCategory : IIdentifiable
     /// <param name="identifier">判定対象の識別子。</param>
     /// <returns>カテゴリ識別子の場合は true、それ以外は false。</returns>
     public static bool IsCategoryIdentifier(string identifier) => identifier.StartsWith(CustomCategoryPrefix) || identifier.StartsWith(TypeCategoryPrefix);
+
     /// <summary>識別子から対応する <see cref="ItemCategory"/> を生成します。解析できない場合は <see cref="ItemType.None"/> のカテゴリを返します。</summary>
     /// <param name="identifier">"type:{数値}" または "custom:{名前}" 形式の識別子。</param>
     /// <returns>生成された <see cref="ItemCategory"/>。</returns>
@@ -44,7 +47,7 @@ public record ItemCategory : IIdentifiable
             }
         }
 
-        return new ItemCategory(ItemType.None);
+        return None;
     }
 
     #region Constructor
@@ -87,4 +90,17 @@ public record ItemCategory : IIdentifiable
     [JsonIgnore] public string Identifier => Type == ItemType.Custom ?
         (CustomCategoryPrefix + CustomCategory) :
         (TypeCategoryPrefix + (int)Type);
+
+    [JsonIgnore] public static readonly ItemCategory None = new(ItemType.None);
+    [JsonIgnore] public static readonly ItemCategory Avatar = new(ItemType.Avatar);
+    [JsonIgnore] public static readonly ItemCategory Clothing = new(ItemType.Clothing);
+    [JsonIgnore] public static readonly ItemCategory Texture = new(ItemType.Texture);
+    [JsonIgnore] public static readonly ItemCategory Gimmick = new(ItemType.Gimmick);
+    [JsonIgnore] public static readonly ItemCategory Accessory = new(ItemType.Accessory);
+    [JsonIgnore] public static readonly ItemCategory HairStyle = new(ItemType.HairStyle);
+    [JsonIgnore] public static readonly ItemCategory Animation = new(ItemType.Animation);
+    [JsonIgnore] public static readonly ItemCategory Tool = new(ItemType.Tool);
+    [JsonIgnore] public static readonly ItemCategory Shader = new(ItemType.Shader);
+    [JsonIgnore] public static readonly ItemCategory All = new(ItemType.All);
+    [JsonIgnore] public static readonly ItemCategory Hidden = new(ItemType.Hidden);
 }

--- a/AvatarExplorer.Core/Models/System/RuntimeSettings.cs
+++ b/AvatarExplorer.Core/Models/System/RuntimeSettings.cs
@@ -39,6 +39,11 @@ public record RuntimeSettings
     public bool TreatEmptySupportedAvatarAsNone { get; init; } = false;
 
     /// <summary>
+    /// アバター選択時にアバターカテゴリを非表示にするかどうか。
+    /// </summary>
+    public bool HideAvatarCategoryWhenAvatarSelected { get; init; } = false;
+
+    /// <summary>
     /// 処理の最大並列数。
     /// </summary>
     public int MaxDegreeOfParallelism { get; init; } = 4;

--- a/AvatarExplorer.Core/Services/Items/ItemCreator.cs
+++ b/AvatarExplorer.Core/Services/Items/ItemCreator.cs
@@ -13,7 +13,7 @@ internal static class ItemCreator
             konoAssetDescription.Creator,
             string.Empty,
             konoAssetDescription.BoothItemId ?? -1,
-            new ItemCategory(ItemType.None),
+            ItemCategory.None,
             konoAssetDescription.Memo ?? string.Empty
         );
         newItem.UpdateThumbnailFileName(konoAssetDescription.ImageFilename ?? string.Empty);

--- a/AvatarExplorer.Core/Services/Items/ItemNavigationService.cs
+++ b/AvatarExplorer.Core/Services/Items/ItemNavigationService.cs
@@ -188,14 +188,19 @@ public class ItemNavigationService
             };
         }).ToList<IIdentifiable>();
 
+        // アバター選択時にアバターカテゴリを非表示にする設定が有効な場合、アバターカテゴリを除外する
+        if (prefix == AvatarPrefix && AvatarExplorerApp.Instance.RuntimeSettings.HideAvatarCategoryWhenAvatarSelected)
+        {
+            categolized.RemoveAll(f => f.Identifier == ItemCategory.Avatar.Identifier);
+        }
+
         // Hidden
         if (items.Any(i => i.IsHidden))
         {
-            var hiddenCategory = new ItemCategory(ItemType.Hidden);
-            categolized.Add(new Folder(hiddenCategory.Identifier)
+            categolized.Add(new Folder(ItemCategory.Hidden.Identifier)
             {
-                Title = hiddenCategory.ToString(),
-                TitleLocalizable = hiddenCategory.IsLocalizable,
+                Title = ItemCategory.Hidden.ToString(),
+                TitleLocalizable = ItemCategory.Hidden.IsLocalizable,
                 ItemCount = items.Count(i => i.IsHidden)
             });
         }

--- a/AvatarExplorer.UI/App.axaml
+++ b/AvatarExplorer.UI/App.axaml
@@ -522,6 +522,7 @@
         <Style Selector="TextBlock.settingslabel.title">
             <Setter Property="FontSize" Value="17"/>
             <Setter Property="FontWeight" Value="Bold"/>
+            <Setter Property="TextWrapping" Value="Wrap"/>
             <Setter Property="Foreground" Value="{DynamicResource Text.Primary}"/>
         </Style>
 

--- a/AvatarExplorer.UI/ViewModels/Overlays/SettingsViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/SettingsViewModel.cs
@@ -49,6 +49,7 @@ public class SettingsViewModel : ViewModelBase, IInitializable
     [Reactive] public bool RemoveOriginal { get; set; }
     [Reactive] public bool LinkToOriginal { get; set; }
     [Reactive] public bool TreatEmptySupportedAvatarAsNone { get; set; }
+    [Reactive] public bool HideAvatarCategoryWhenAvatarSelected { get; set; }
     [Reactive] public double ThumbnailCompressionMaxSize { get; set; }
     [Reactive] public bool UseBackgroundImage { get; set; }
     [Reactive] public string BackgroundImagePath { get; set; } = string.Empty;
@@ -155,6 +156,7 @@ public class SettingsViewModel : ViewModelBase, IInitializable
         RemoveOriginal = runtimeSettings.RemoveOriginal;
         LinkToOriginal = runtimeSettings.ShouldLinkToOriginal;
         TreatEmptySupportedAvatarAsNone = runtimeSettings.TreatEmptySupportedAvatarAsNone;
+        HideAvatarCategoryWhenAvatarSelected = runtimeSettings.HideAvatarCategoryWhenAvatarSelected;
         ThumbnailCompressionMaxSize = preferences.ThumbnailCompressionMaxEdge;
         UseBackgroundImage = preferences.UseBackgroundImage;
         BackgroundImagePath = preferences.BackgroundImage;
@@ -447,6 +449,7 @@ public class SettingsViewModel : ViewModelBase, IInitializable
             ShouldLinkToOriginal = LinkToOriginal,
             AutoBackupInterval = ValueParser.Int(AutoBackupInterval, 5),
             TreatEmptySupportedAvatarAsNone = TreatEmptySupportedAvatarAsNone,
+            HideAvatarCategoryWhenAvatarSelected = HideAvatarCategoryWhenAvatarSelected,
             MaxDegreeOfParallelism = ValueParser.Int(MaxDegreeOfParallelism, 4),
             AutoChangeUnitypackagePath = AutoChangeUnitypackagePath,
             CheckForUpdate = CheckForUpdate,

--- a/AvatarExplorer.UI/Views/Overlays/SettingsOverlay.axaml
+++ b/AvatarExplorer.UI/Views/Overlays/SettingsOverlay.axaml
@@ -281,6 +281,17 @@
 
                                     <Grid ColumnDefinitions="*,*" ColumnSpacing="10">
                                         <Grid Grid.Column="0" RowDefinitions="Auto,*" RowSpacing="5">
+                                            <TextBlock Classes="settingslabel title" Grid.Row="0" Text="{Binding [Settings.HideAvatarCategoryWhenAvatarSelected.Title], Source={x:Static loc:Localizer.Instance}}"/>
+                                            <TextBlock Classes="settingslabel description" Grid.Row="1" Text="{Binding [Settings.HideAvatarCategoryWhenAvatarSelected.Description], Source={x:Static loc:Localizer.Instance}}"/>
+                                        </Grid>
+
+                                        <Grid Grid.Column="1" ColumnDefinitions="*,Auto" ColumnSpacing="5">
+                                            <ToggleSwitch IsChecked="{Binding HideAvatarCategoryWhenAvatarSelected}" Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Right"/>
+                                        </Grid>
+                                    </Grid>
+
+                                    <Grid ColumnDefinitions="*,*" ColumnSpacing="10">
+                                        <Grid Grid.Column="0" RowDefinitions="Auto,*" RowSpacing="5">
                                             <TextBlock Classes="settingslabel title" Grid.Row="0" Text="{Binding [Settings.TagEditor.Title], Source={x:Static loc:Localizer.Instance}}"/>
                                             <TextBlock Classes="settingslabel description" Grid.Row="1" Text="{Binding [Settings.TagEditor.Description], Source={x:Static loc:Localizer.Instance}}"/>
                                         </Grid>

--- a/docs/07-runtime-settings.md
+++ b/docs/07-runtime-settings.md
@@ -40,6 +40,9 @@ public record RuntimeSettings
     // 対応アバターが空の場合に「なし」として扱うか
     public bool TreatEmptySupportedAvatarAsNone { get; init; }
 
+    // アバター選択時にアバターカテゴリを非表示にするか
+    public bool HideAvatarCategoryWhenAvatarSelected { get; init; }
+
     // 最大並列処理数
     public int MaxDegreeOfParallelism { get; init; }
 


### PR DESCRIPTION
Add HideAvatarCategoryWhenAvatarSelected runtime setting that excludes the avatar category from the category list when selecting items from an avatar. Introduce static ItemCategory shortcuts and reuse them in ItemCreator and ItemNavigationService.