### PR TITLE
refactor(items): reuse static ItemCategory instances via factory methods

### DIFF
--- a/AvatarExplorer.Core/Models/External/Booth/BoothItem.cs
+++ b/AvatarExplorer.Core/Models/External/Booth/BoothItem.cs
@@ -47,7 +47,7 @@ public record BoothItem
     /// 商品名とカテゴリから推定された AvatarExplorer のアイテムカテゴリ。
     /// </summary>
     [JsonIgnore]
-    public ItemCategory EstimatedCategory { get; init; } = new(ItemType.None);
+    public ItemCategory EstimatedCategory { get; init; } = ItemCategory.Get(ItemType.None);
 
     /// <summary>
     /// サムネイル画像のうち最初の画像の URL。画像が存在しない場合は空文字列。

--- a/AvatarExplorer.Core/Models/External/KonoAsset/Items/KonoAssetAvatarItem.cs
+++ b/AvatarExplorer.Core/Models/External/KonoAsset/Items/KonoAssetAvatarItem.cs
@@ -16,7 +16,7 @@ public class KonoAssetAvatarItem : AbstractKonoAssetItem
     {
         Item migratedItem = ItemCreator.FromKonoAssetDescription(Description);
         migratedItem.UpdateItemPath($"<sys>{Id}");
-        migratedItem.UpdateCategory(new ItemCategory(ItemType.Avatar));
+        migratedItem.UpdateCategory(ItemCategory.Get(ItemType.Avatar));
 
         return migratedItem;
     }

--- a/AvatarExplorer.Core/Models/External/KonoAsset/Items/KonoAssetOtherItem.cs
+++ b/AvatarExplorer.Core/Models/External/KonoAsset/Items/KonoAssetOtherItem.cs
@@ -24,7 +24,7 @@ public class KonoAssetOtherItem : AbstractKonoAssetItem
     {
         var migratedItem = ItemCreator.FromKonoAssetDescription(Description);
         migratedItem.UpdateItemPath(ItemUtils.RootFolderPrefix + Id);
-        migratedItem.UpdateCategory(new ItemCategory(string.IsNullOrEmpty(Category) ? "Others (KonoAsset)" : $"{Category} (KonoAsset)" ));
+        migratedItem.UpdateCategory(ItemCategory.Get(string.IsNullOrEmpty(Category) ? "Others (KonoAsset)" : $"{Category} (KonoAsset)" ));
 
         return migratedItem;
     }

--- a/AvatarExplorer.Core/Models/External/KonoAsset/Items/KonoAssetWearableItem.cs
+++ b/AvatarExplorer.Core/Models/External/KonoAsset/Items/KonoAssetWearableItem.cs
@@ -30,7 +30,7 @@ public class KonoAssetWearableItem : AbstractKonoAssetItem
     {
         var migratedItem = ItemCreator.FromKonoAssetDescription(Description);
         migratedItem.UpdateItemPath(ItemUtils.RootFolderPrefix + Id);
-        migratedItem.UpdateCategory(new ItemCategory(string.IsNullOrEmpty(Category) ? "Wearables (KonoAsset)" : $"{Category} (KonoAsset)" ));
+        migratedItem.UpdateCategory(ItemCategory.Get(string.IsNullOrEmpty(Category) ? "Wearables (KonoAsset)" : $"{Category} (KonoAsset)" ));
         migratedItem.UpdateSupportedAvatars(SupportedAvatars);
 
         return migratedItem;

--- a/AvatarExplorer.Core/Models/External/KonoAsset/Items/KonoAssetWorldItem.cs
+++ b/AvatarExplorer.Core/Models/External/KonoAsset/Items/KonoAssetWorldItem.cs
@@ -24,7 +24,7 @@ public class KonoAssetWorldItem : AbstractKonoAssetItem
     {
         var migratedItem = ItemCreator.FromKonoAssetDescription(Description);
         migratedItem.UpdateItemPath(ItemUtils.RootFolderPrefix + Id);
-        migratedItem.UpdateCategory(new ItemCategory(string.IsNullOrEmpty(Category) ? "Worlds (KonoAsset)" : $"{Category} (KonoAsset)"));
+        migratedItem.UpdateCategory(ItemCategory.Get(string.IsNullOrEmpty(Category) ? "Worlds (KonoAsset)" : $"{Category} (KonoAsset)"));
 
         return migratedItem;
     }

--- a/AvatarExplorer.Core/Models/Items/Item.cs
+++ b/AvatarExplorer.Core/Models/Items/Item.cs
@@ -28,7 +28,7 @@ public class Item : AbstractDatabaseItem, IIdentifiable
     /// <summary>サムネイル画像のファイル名です。</summary>
     [JsonInclude] public string ThumbnailFileName { get; private set; } = string.Empty;
     /// <summary>アイテムのカテゴリ（組み込みタイプとカスタムカテゴリ）です。</summary>
-    [JsonInclude] public ItemCategory Category { get; private set; } = new(ItemType.None);
+    [JsonInclude] public ItemCategory Category { get; private set; } = ItemCategory.Get(ItemType.None);
     /// <summary>対応アバターの識別子（Identifier）一覧です。</summary>
     [JsonInclude] public ImmutableArray<string> SupportedAvatars { get; private set; } = [];
     /// <summary>実装済みアバターの識別子（Identifier）一覧です。</summary>
@@ -59,7 +59,7 @@ public class Item : AbstractDatabaseItem, IIdentifiable
         Author = author;
         AuthorId = authorId;
         BoothId = boothId;
-        Category = new ItemCategory(category);
+        Category = ItemCategory.Copy(category);
         ItemMemo = itemMemo;
     }
 
@@ -77,7 +77,7 @@ public class Item : AbstractDatabaseItem, IIdentifiable
     public void UpdateBoothId(int boothId) => BoothId = boothId;
     /// <summary>カテゴリを更新します。</summary>
     /// <param name="category">新しいカテゴリ。</param>
-    public void UpdateCategory(ItemCategory category) => Category = new ItemCategory(category);
+    public void UpdateCategory(ItemCategory category) => Category = category;
     /// <summary>メモを更新します。</summary>
     /// <param name="memo">新しいメモ。</param>
     public void UpdateMemo(string memo) => ItemMemo = memo;

--- a/AvatarExplorer.Core/Models/Items/ItemCategory.cs
+++ b/AvatarExplorer.Core/Models/Items/ItemCategory.cs
@@ -36,14 +36,14 @@ public record ItemCategory : IIdentifiable
     {
         if (identifier.StartsWith(CustomCategoryPrefix))
         {
-            return new ItemCategory(identifier[CustomCategoryPrefix.Length..]);
+            return Get(identifier[CustomCategoryPrefix.Length..]);
         }
         else if (identifier.StartsWith(TypeCategoryPrefix))
         {
             var typeString = identifier[TypeCategoryPrefix.Length..];
             if (int.TryParse(typeString, out int typeValue) && Enum.IsDefined(typeof(ItemType), typeValue))
             {
-                return new ItemCategory((ItemType)typeValue);
+                return GetFromType((ItemType)typeValue);
             }
         }
 
@@ -51,36 +51,52 @@ public record ItemCategory : IIdentifiable
     }
 
     #region Constructor
-    /// <summary><see cref="ItemType.None"/> を持つ空のカテゴリを初期化します。</summary>
-    public ItemCategory()
+    [JsonConstructor]
+    private ItemCategory()
     {
     }
-
-    /// <summary>既存の <see cref="ItemCategory"/> をコピーして新しいカテゴリを初期化します。</summary>
-    /// <param name="category">コピー元のカテゴリ。</param>
-    public ItemCategory(ItemCategory category)
-    {
-        Type = category.Type;
-        CustomCategory = category.CustomCategory;
-    }
-
-    /// <summary>指定した組み込みタイプ（および任意のカスタムカテゴリ名）を持つカテゴリを初期化します。customCategory が空でない場合は <see cref="ItemType.Custom"/> として扱われます。</summary>
-    /// <param name="type">組み込みカテゴリタイプ。</param>
-    /// <param name="customCategory">カスタムカテゴリ名。空の場合は type がそのまま使用されます。</param>
-    public ItemCategory(ItemType type, string customCategory = "")
+    private ItemCategory(ItemType type, string customCategory = "")
     {
         Type = string.IsNullOrEmpty(customCategory) ? type : ItemType.Custom;
         CustomCategory = customCategory;
     }
-
-    /// <summary>指定したカスタムカテゴリ名を持つカテゴリ（<see cref="ItemType.Custom"/>）を初期化します。</summary>
-    /// <param name="customCategory">カスタムカテゴリ名。</param>
-    public ItemCategory(string customCategory)
+    private ItemCategory(string customCategory)
     {
         Type = ItemType.Custom;
         CustomCategory = customCategory;
     }
     #endregion
+
+    /// <summary>
+    /// 指定したカテゴリをコピーして新しいカテゴリを初期化します。
+    /// </summary>
+    /// <param name="category">コピー元のカテゴリ。</param>
+    /// <returns>コピーされた新しいカテゴリ。</returns>
+    public static ItemCategory Copy(ItemCategory category)
+    {
+        if (category.Type != ItemType.Custom)
+            return GetFromType(category.Type);
+        return new ItemCategory(category.CustomCategory);
+    }
+
+    /// <summary>指定した組み込みタイプ（および任意のカスタムカテゴリ名）を持つカテゴリを初期化します。customCategory が空でない場合は <see cref="ItemType.Custom"/> として扱われます。</summary>
+    /// <param name="type">組み込みカテゴリタイプ。</param>
+    /// <param name="customCategory">カスタムカテゴリ名。空の場合は type がそのまま使用されます。</param>
+    public static ItemCategory Get(ItemType type = ItemType.None, string customCategory = "")
+    {
+        if (string.IsNullOrEmpty(customCategory))
+        {
+            return GetFromType(type);
+        }
+        else
+        {
+            return Get(customCategory);
+        }
+    }
+    public static ItemCategory Get(string customCategory)
+    {
+        return new ItemCategory(customCategory);
+    }
 
     /// <summary>カテゴリの表示名を返します。カスタムカテゴリの場合はその名前、それ以外はローカライズキー（または enum 名）になります。</summary>
     /// <returns>カテゴリの表示名。</returns>
@@ -91,16 +107,36 @@ public record ItemCategory : IIdentifiable
         (CustomCategoryPrefix + CustomCategory) :
         (TypeCategoryPrefix + (int)Type);
 
-    [JsonIgnore] public static readonly ItemCategory None = new(ItemType.None);
-    [JsonIgnore] public static readonly ItemCategory Avatar = new(ItemType.Avatar);
-    [JsonIgnore] public static readonly ItemCategory Clothing = new(ItemType.Clothing);
-    [JsonIgnore] public static readonly ItemCategory Texture = new(ItemType.Texture);
-    [JsonIgnore] public static readonly ItemCategory Gimmick = new(ItemType.Gimmick);
-    [JsonIgnore] public static readonly ItemCategory Accessory = new(ItemType.Accessory);
-    [JsonIgnore] public static readonly ItemCategory HairStyle = new(ItemType.HairStyle);
-    [JsonIgnore] public static readonly ItemCategory Animation = new(ItemType.Animation);
-    [JsonIgnore] public static readonly ItemCategory Tool = new(ItemType.Tool);
-    [JsonIgnore] public static readonly ItemCategory Shader = new(ItemType.Shader);
-    [JsonIgnore] public static readonly ItemCategory All = new(ItemType.All);
-    [JsonIgnore] public static readonly ItemCategory Hidden = new(ItemType.Hidden);
+    [JsonIgnore] private static readonly ItemCategory None = new(ItemType.None);
+    [JsonIgnore] private static readonly ItemCategory Avatar = new(ItemType.Avatar);
+    [JsonIgnore] private static readonly ItemCategory Clothing = new(ItemType.Clothing);
+    [JsonIgnore] private static readonly ItemCategory Texture = new(ItemType.Texture);
+    [JsonIgnore] private static readonly ItemCategory Gimmick = new(ItemType.Gimmick);
+    [JsonIgnore] private static readonly ItemCategory Accessory = new(ItemType.Accessory);
+    [JsonIgnore] private static readonly ItemCategory HairStyle = new(ItemType.HairStyle);
+    [JsonIgnore] private static readonly ItemCategory Animation = new(ItemType.Animation);
+    [JsonIgnore] private static readonly ItemCategory Tool = new(ItemType.Tool);
+    [JsonIgnore] private static readonly ItemCategory Shader = new(ItemType.Shader);
+    [JsonIgnore] private static readonly ItemCategory All = new(ItemType.All);
+    [JsonIgnore] private static readonly ItemCategory Hidden = new(ItemType.Hidden);
+
+    private static ItemCategory GetFromType(ItemType type)
+    {
+        return type switch
+        {
+            ItemType.None => None,
+            ItemType.Avatar => Avatar,
+            ItemType.Clothing => Clothing,
+            ItemType.Texture => Texture,
+            ItemType.Gimmick => Gimmick,
+            ItemType.Accessory => Accessory,
+            ItemType.HairStyle => HairStyle,
+            ItemType.Animation => Animation,
+            ItemType.Tool => Tool,
+            ItemType.Shader => Shader,
+            ItemType.All => All,
+            ItemType.Hidden => Hidden,
+            _ => new ItemCategory(type)
+        };
+    }
 }

--- a/AvatarExplorer.Core/Services/IO/DataImporter.cs
+++ b/AvatarExplorer.Core/Services/IO/DataImporter.cs
@@ -166,7 +166,7 @@ public class DataImporter(ItemRepository items, CommonAvatarRepository commonAva
             v1Item.AuthorName,
             v1Item.AuthorId,
             v1Item.BoothId,
-            new ItemCategory((ItemType)(v1Item.Type + 1), v1Item.CustomCategory),
+            ItemCategory.Get((ItemType)(v1Item.Type + 1), v1Item.CustomCategory),
             v1Item.ItemMemo
         );
         item.SetCreationDates(v1Item.CreatedDate, v1Item.UpdatedDate);

--- a/AvatarExplorer.Core/Services/Items/ItemCreator.cs
+++ b/AvatarExplorer.Core/Services/Items/ItemCreator.cs
@@ -13,7 +13,7 @@ internal static class ItemCreator
             konoAssetDescription.Creator,
             string.Empty,
             konoAssetDescription.BoothItemId ?? -1,
-            ItemCategory.None,
+            ItemCategory.Get(ItemType.None),
             konoAssetDescription.Memo ?? string.Empty
         );
         newItem.UpdateThumbnailFileName(konoAssetDescription.ImageFilename ?? string.Empty);

--- a/AvatarExplorer.Core/Services/Items/ItemNavigationService.cs
+++ b/AvatarExplorer.Core/Services/Items/ItemNavigationService.cs
@@ -191,16 +191,17 @@ public class ItemNavigationService
         // アバター選択時にアバターカテゴリを非表示にする設定が有効な場合、アバターカテゴリを除外する
         if (prefix == AvatarPrefix && AvatarExplorerApp.Instance.RuntimeSettings.HideAvatarCategoryWhenAvatarSelected)
         {
-            categolized.RemoveAll(f => f.Identifier == ItemCategory.Avatar.Identifier);
+            categolized.RemoveAll(f => f.Identifier == ItemCategory.Get(ItemType.Avatar).Identifier);
         }
 
         // Hidden
         if (items.Any(i => i.IsHidden))
         {
-            categolized.Add(new Folder(ItemCategory.Hidden.Identifier)
+            var hiddenCategory = ItemCategory.Get(ItemType.Hidden);
+            categolized.Add(new Folder(hiddenCategory.Identifier)
             {
-                Title = ItemCategory.Hidden.ToString(),
-                TitleLocalizable = ItemCategory.Hidden.IsLocalizable,
+                Title = hiddenCategory.ToString(),
+                TitleLocalizable = hiddenCategory.IsLocalizable,
                 ItemCount = items.Count(i => i.IsHidden)
             });
         }

--- a/AvatarExplorer.Core/Services/System/BoothService.cs
+++ b/AvatarExplorer.Core/Services/System/BoothService.cs
@@ -40,7 +40,7 @@ public static class BoothService
 
             return boothItem with
             {
-                EstimatedCategory = new(SuggestItemType(boothItem.Title, boothItem.Category.Name)),
+                EstimatedCategory = ItemCategory.Get(SuggestItemType(boothItem.Title, boothItem.Category.Name)),
             };
         }
         catch (Exception)

--- a/AvatarExplorer.Core/Services/System/ItemGroupService.cs
+++ b/AvatarExplorer.Core/Services/System/ItemGroupService.cs
@@ -120,7 +120,7 @@ public class ItemGroupService
 
         if (includeAllCategory)
         {
-            categories.Add(new Folder(new ItemCategory(ItemType.All).Identifier)
+            categories.Add(new Folder(ItemCategory.Get(ItemType.All).Identifier)
             {
                 Title = ItemType.All.GetLocalizationKey() ?? string.Empty,
                 TitleLocalizable = true,
@@ -145,7 +145,7 @@ public class ItemGroupService
                 .Where(i => i.IsSelectable() && (includeEmptyCategory || existCategories.Contains(i)))
                 .Select(i =>
                 {
-                    return new Folder(new ItemCategory(i).Identifier)
+                    return new Folder(ItemCategory.Get(i).Identifier)
                     {
                         Title = i.GetLocalizationKey() ?? string.Empty,
                         TitleLocalizable = true,
@@ -156,7 +156,7 @@ public class ItemGroupService
 
         categories.AddRange(existCustomCategories.Select(i =>
         {
-            return new Folder(new ItemCategory(i).Identifier)
+            return new Folder(ItemCategory.Get(i).Identifier)
             {
                 Title = i,
                 TitleLocalizable = false,
@@ -169,7 +169,7 @@ public class ItemGroupService
             var hiddenCount = items.Count(i => i.IsHidden);
             if (hiddenCount > 0)
             {
-                var hiddenCategory = new ItemCategory(ItemType.Hidden);
+                var hiddenCategory = ItemCategory.Get(ItemType.Hidden);
                 categories.Add(new Folder(hiddenCategory.Identifier)
                 {
                     Title = hiddenCategory.ToString(),

--- a/AvatarExplorer.Core/Services/System/Repositories/ItemRepository.cs
+++ b/AvatarExplorer.Core/Services/System/Repositories/ItemRepository.cs
@@ -61,7 +61,7 @@ public class ItemRepository : RepositoryBase<Item>
             context.Author,
             context.AuthorId,
             context.BoothId,
-            new ItemCategory(context.ItemType, context.CustomCategory),
+            ItemCategory.Get(context.ItemType, context.CustomCategory),
             context.ItemMemo
         );
         var now = DatetimeUtils.GetCurrentUnixTime();
@@ -132,7 +132,7 @@ public class ItemRepository : RepositoryBase<Item>
         if (context.Author != null) item.UpdateAuthor(context.Author);
         if (context.AuthorId != null) item.UpdateAuthorId(context.AuthorId);
         if (context.BoothId != null) item.UpdateBoothId(context.BoothId.Value);
-        if (context.ItemType != null) item.UpdateCategory(new ItemCategory(context.ItemType.Value, context.CustomCategory ?? item.Category.CustomCategory));
+        if (context.ItemType != null) item.UpdateCategory(ItemCategory.Get(context.ItemType.Value, context.CustomCategory ?? item.Category.CustomCategory));
         if (context.ItemMemo != null) item.UpdateMemo(context.ItemMemo);
         if (context.ItemPath != null) item.UpdateItemPath(context.ItemPath);
         if (context.IsHidden != null) item.UpdateIsHidden(context.IsHidden.Value);
@@ -363,7 +363,7 @@ public class ItemRepository : RepositoryBase<Item>
     /// <param name="newName">変更後のカスタムカテゴリ名。</param>
     public void RenameCustomCategory(string oldname, string newName)
     {
-        var newCategory = new ItemCategory(newName);
+        var newCategory = ItemCategory.Get(newName);
 
         GetAll()
             .Where(i => i.Category.Type == ItemType.Custom && i.Category.CustomCategory == oldname)
@@ -464,7 +464,7 @@ public class ItemRepository : RepositoryBase<Item>
             if (unknownCategoryExists) offset = (int)items.Max(i => i.Category.Type) - (int)ItemType.Custom;
             foreach (var item in items)
             {
-                item.UpdateCategory(new(item.Category.Type - offset, item.Category.CustomCategory));
+                item.UpdateCategory(ItemCategory.Get(item.Category.Type - offset, item.Category.CustomCategory));
             }
 
             Save();

--- a/AvatarExplorer.UI/ViewModels/Component/ItemCategoryViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Component/ItemCategoryViewModel.cs
@@ -7,7 +7,7 @@ namespace AvatarExplorer.UI.ViewModels.Component;
 public class ItemCategoryViewModel(ItemCategory category) : ViewModelBase
 {
     [Reactive] public string DisplayName { get; set; } = string.Empty;
-    public ItemCategory Category { get; } = new(category);
+    public ItemCategory Category { get; } = ItemCategory.Copy(category);
 
     public ItemCategoryViewModel Update()
     {

--- a/AvatarExplorer.UI/ViewModels/Overlays/ItemEditorViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/ItemEditorViewModel.cs
@@ -460,7 +460,7 @@ public class ItemEditorViewModel : ViewModelBase
         var newCategory = await InstanceRepository.MainWindow.ShowTextDialog(Localizer.Instance[Loc.Dialog.Title.AddCustomCategory]);
         if (string.IsNullOrEmpty(newCategory)) return;
 
-        Categories.Add(new ItemCategoryViewModel(new ItemCategory(newCategory)).Update());
+        Categories.Add(new ItemCategoryViewModel(ItemCategory.Get(newCategory)).Update());
         SelectedCategoryIndex = Categories.Count - 1;
     }
 

--- a/AvatarExplorer.UI/ViewModels/Overlays/MergeCategoryViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Overlays/MergeCategoryViewModel.cs
@@ -45,7 +45,7 @@ public class MergeCategoryViewModel : ViewModelBase
         var sourceIndex = GetCategoryIndex(ItemCategory.FromIdentifier(state));
         SelectedSourceCategoryIndex = Categories.IsValidIndex(sourceIndex) ? sourceIndex : 0;
 
-        var targetIndex = GetCategoryIndex(new(ItemType.Avatar));
+        var targetIndex = GetCategoryIndex(ItemCategory.Get(ItemType.Avatar));
         SelectedTargetCategoryIndex = Categories.IsValidIndex(targetIndex) ? targetIndex : 0;
 
         IsVisible = true;

--- a/docs/01-getting-started.md
+++ b/docs/01-getting-started.md
@@ -238,11 +238,11 @@ var category2 = ItemCategory.FromIdentifier("custom:マイカテゴリ"); // Cus
 var category3 = ItemCategory.FromIdentifier("invalid");            // ItemType.None
 
 // 表示名を取得
-var category = new ItemCategory(ItemType.Clothing);
+var category = ItemCategory.Get(ItemType.Clothing);
 Console.WriteLine(category.ToString());        // "ItemCategory.Clothing" (LocalizationKey)
 Console.WriteLine(category.Identifier);        // "type:2"
 
-var customCategory = new ItemCategory("オリジナル");
+var customCategory = ItemCategory.Get("オリジナル");
 Console.WriteLine(customCategory.ToString());  // "オリジナル"
 Console.WriteLine(customCategory.Identifier);  // "custom:オリジナル"
 ```

--- a/docs/02-navigation-system.md
+++ b/docs/02-navigation-system.md
@@ -76,7 +76,7 @@ Identifierを指定して選択を行います。
 navigation.Select("avatar:item:e10abf3d-cca7-4117-a5e9-52926a4f8990");
 
 // カテゴリを選択
-navigation.Select("type:2"); // = new ItemCategory(ItemType.Clothing).Identifier
+navigation.Select("type:2"); // = ItemCategory.Get(ItemType.Clothing).Identifier
 
 // アイテムを選択
 navigation.Select("item:91517db1-eaf3-4137-914f-551cf3669692");

--- a/docs/03-item-management.md
+++ b/docs/03-item-management.md
@@ -328,8 +328,8 @@ itemRepo.RenameCustomCategory("旧カテゴリ名", "新カテゴリ名");
 ### MergeCategory() - カテゴリのマージ
 
 ```csharp
-var sourceCategory = new ItemCategory(ItemType.Texture);
-var targetCategory = new ItemCategory(ItemType.Clothing);
+var sourceCategory = ItemCategory.Get(ItemType.Texture);
+var targetCategory = ItemCategory.Get(ItemType.Clothing);
 
 itemRepo.MergeCategory(sourceCategory, targetCategory);
 // Textureカテゴリのアイテムが全てClothingカテゴリに移動


### PR DESCRIPTION
Replace public ItemCategory constructors with Get/Copy factory methods that return cached static instances for built-in ItemTypes, preventing unnecessary instance duplication. Custom categories still create new instances since they cannot be cached.