### PR TITLE
refactor(items): remove unnecessary ItemCategory.Copy

### DIFF
--- a/AvatarExplorer.Core/Models/Items/Item.cs
+++ b/AvatarExplorer.Core/Models/Items/Item.cs
@@ -59,7 +59,7 @@ public class Item : AbstractDatabaseItem, IIdentifiable
         Author = author;
         AuthorId = authorId;
         BoothId = boothId;
-        Category = ItemCategory.Copy(category);
+        Category = category;
         ItemMemo = itemMemo;
     }
 

--- a/AvatarExplorer.Core/Models/Items/ItemCategory.cs
+++ b/AvatarExplorer.Core/Models/Items/ItemCategory.cs
@@ -67,18 +67,6 @@ public record ItemCategory : IIdentifiable
     }
     #endregion
 
-    /// <summary>
-    /// 指定したカテゴリをコピーして新しいカテゴリを初期化します。
-    /// </summary>
-    /// <param name="category">コピー元のカテゴリ。</param>
-    /// <returns>コピーされた新しいカテゴリ。</returns>
-    public static ItemCategory Copy(ItemCategory category)
-    {
-        if (category.Type != ItemType.Custom)
-            return GetFromType(category.Type);
-        return new ItemCategory(category.CustomCategory);
-    }
-
     /// <summary>指定した組み込みタイプ（および任意のカスタムカテゴリ名）を持つカテゴリを初期化します。customCategory が空でない場合は <see cref="ItemType.Custom"/> として扱われます。</summary>
     /// <param name="type">組み込みカテゴリタイプ。</param>
     /// <param name="customCategory">カスタムカテゴリ名。空の場合は type がそのまま使用されます。</param>

--- a/AvatarExplorer.UI/ViewModels/Component/ItemCategoryViewModel.cs
+++ b/AvatarExplorer.UI/ViewModels/Component/ItemCategoryViewModel.cs
@@ -7,7 +7,7 @@ namespace AvatarExplorer.UI.ViewModels.Component;
 public class ItemCategoryViewModel(ItemCategory category) : ViewModelBase
 {
     [Reactive] public string DisplayName { get; set; } = string.Empty;
-    public ItemCategory Category { get; } = ItemCategory.Copy(category);
+    public ItemCategory Category { get; } = category;
 
     public ItemCategoryViewModel Update()
     {


### PR DESCRIPTION
ItemCategory is an immutable record with init-only properties, so creating defensive copies provides no benefit. Replace ItemCategory.Copy with direct assignment in Item.UpdateMetadata and ItemCategoryViewModel.