### PR TITLE
chore(ui): update Avalonia packages to 12.1.2

### DIFF
--- a/AvatarExplorer.UI/AvatarExplorer.UI.csproj
+++ b/AvatarExplorer.UI/AvatarExplorer.UI.csproj
@@ -14,18 +14,11 @@
 		<DebugType>none</DebugType>
 	</PropertyGroup>
 
-	<PropertyGroup>
-		<!-- example $ dotnet build -p:AvaloniaVersion=Nightly  -->
-		<AE-AvaloniaVersion Condition="'$(AvaloniaVersion)'=='Nightly'">12.2.999-cibuild0068408-alpha</AE-AvaloniaVersion>
-		<AE-AvaloniaVersion Condition="'$(AvaloniaVersion)'=='LocalBuild'">9999.0.0-localbuild</AE-AvaloniaVersion>
-		<AE-AvaloniaVersion Condition="'$(AE-AvaloniaVersion)'==''">12.0.4</AE-AvaloniaVersion>
-	</PropertyGroup>
-
 	<ItemGroup>
-		<PackageReference Include="Avalonia" Version="$(AE-AvaloniaVersion)" />
-		<PackageReference Include="Avalonia.Desktop" Version="$(AE-AvaloniaVersion)" />
-		<PackageReference Include="Avalonia.Themes.Fluent" Version="$(AE-AvaloniaVersion)" />
-		<PackageReference Include="Avalonia.Fonts.Inter" Version="$(AE-AvaloniaVersion)" />
+		<PackageReference Include="Avalonia" Version="12.1.2" />
+		<PackageReference Include="Avalonia.Desktop" Version="12.1.2" />
+		<PackageReference Include="Avalonia.Themes.Fluent" Version="12.1.2" />
+		<PackageReference Include="Avalonia.Fonts.Inter" Version="12.1.2" />
 
 		<PackageReference Include="Avalonia.Controls.DataGrid" Version="12.0.0" />
 		<PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.1" />


### PR DESCRIPTION
- Remove conditional PropertyGroup for Nightly/LocalBuild Avalonia versions
- Hardcode Avalonia 12.1.2 for Avalonia, Desktop, Themes.Fluent, and Fonts.Inter packages